### PR TITLE
[Control] fixed addon call

### DIFF
--- a/lib/openscrapers/modules/control.py
+++ b/lib/openscrapers/modules/control.py
@@ -31,16 +31,17 @@ import xbmcvfs
 integer = 1000
 
 addon = xbmcaddon.Addon
-AddonID = xbmcaddon.Addon().getAddonInfo('id')
-addonInfo = xbmcaddon.Addon().getAddonInfo
+addonObject = addon('script.module.openscrapers')
+AddonID = addonObject.getAddonInfo('id')
+addonInfo = addonObject.getAddonInfo
 addonName = addonInfo('name')
 addonVersion = addonInfo('version')
 
-lang = xbmcaddon.Addon().getLocalizedString
+lang = addonObject.getLocalizedString
 lang2 = xbmc.getLocalizedString
 
-setting = xbmcaddon.Addon().getSetting
-setSetting = xbmcaddon.Addon().setSetting
+setting = addonObject.getSetting
+setSetting = addonObject.setSetting
 
 addItem = xbmcplugin.addDirectoryItem
 item = xbmcgui.ListItem
@@ -75,9 +76,9 @@ skinPath = xbmc.translatePath('special://skin/')
 
 # addonPath = xbmc.translatePath(addonInfo('path'))
 try:
-	addonPath = xbmcaddon.Addon().getAddonInfo('path').decode('utf-8')
+	addonPath = addonObject.getAddonInfo('path').decode('utf-8')
 except:
-	addonPath = xbmcaddon.Addon().getAddonInfo('path')
+	addonPath = addonObject.getAddonInfo('path')
 
 # dataPath = xbmc.translatePath(addonInfo('profile')).decode('utf-8')
 try:


### PR DESCRIPTION
I hardcoded the addonID in the control.py

## Why?
because if I want to call settings from openscrapers in a provider module, than for example plugin.video.venoms settings are called.
