### PR TITLE
Updated settings.xml for EasyNews

### DIFF
--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -39,6 +39,7 @@
         <setting id="provider.cmovieshd" type="bool" label="CMOVIESHD" default="true"/>
         <setting id="provider.coolmoviezone" type="bool" label="COOLMOVIEZONE" default="true"/>
         <setting id="provider.divxcrawler" type="bool" label="DIVXCRAWLER" default="true"/>
+        <setting id="provider.easynews" type="bool" label="EASYNEWS" default="true"/>
         <setting id="provider.extramovies" type="bool" label="EXTRAMOVIES" default="true"/>
         <setting id="provider.filmxy" type="bool" label="FILMXY" default="true"/>
         <setting id="provider.fmovies" type="bool" label="FMOVIES" default="true"/>
@@ -64,7 +65,7 @@
         <setting id="provider.putlockeronline" type="bool" label="PUTLOCKERONLINE" default="true"/>
         <setting id="provider.seehd" type="bool" label="SEEHD" default="true"/>
         <setting id="provider.series9" type="bool" label="SERIES9" default="true"/>
-        <setting id="provider.seriesonline" type="bool" label="SERIESONLINE" default="true"/>
+		<setting id="provider.seriesonline" type="bool" label="SERIESONLINE" default="true"/>
         <setting id="provider.sharemovies" type="bool" label="SHAREMOVIES" default="true"/>
         <setting id="provider.solarmoviefree" type="bool" label="SOLARMOVIEFREE" default="true"/>
         <setting id="provider.streamdreams" type="bool" label="STREAMDREAMS" default="true"/>
@@ -236,7 +237,7 @@
                  action="RunPlugin(plugin://script.module.openscrapers/?action=toggleAllTorrent&amp;setting=false&amp;query=5.0)"/>
         <setting label="Enable All Torrent Providers" type="action" option="close"
                  action="RunPlugin(plugin://script.module.openscrapers/?action=toggleAllTorrent&amp;setting=true&amp;query=5.1)"/>
-        <setting id="torrent.enabled" type="bool" label="Enable Torrent Scrapers" default="true" visible = "false" />
+		<setting id="torrent.enabled" type="bool" label="Enable Torrent Scrapers" default="true" visible = "false" />
         <setting type="sep"/>
         <setting id="provider.1337x" type="bool" label="$NUMBER[1337]X" default="true"/>
         <setting id="provider.bitlord" type="bool" label="BITLORD" default="true"/>
@@ -269,8 +270,10 @@
         <setting id="furk.user_name" type="text" label="Furk Username" default=""/>
         <setting id="furk.user_pass" type="text" label="Furk Password" option="hidden" default=""/>
         <setting id="furk.api" type="text" label="Furk API Key" default=""/>
-        <!--    <setting id="furk.mod.level" type="labelenum" label="Set Furk Moderation Level" default="Yes" values="No|Yes|Full" />   -->
-        <setting id="furk.limit" label="Limit results" type="slider" default="25" range="5,5,200" option="int"/>
+
+        <setting type="lsep" label="Easynews"/>
+        <setting id="easynews.user" type="text" label="Easynews Username" default=""/>
+        <setting id="easynews.password" type="text" label="Easynews Password" default=""/>
 
         <setting type="lsep" label="Ororo.tv"/>
         <setting id="ororo.user" type="text" label="Email" default=""/>


### PR DESCRIPTION
added back the EasyNews settings added by TikiPete.  I acidently over-wrote them and this should fix it with included escape characters added back also.