### PR TITLE
Check scraper enabled/disabled before importing the scraper's class and adding to sourceDict.

### DIFF
--- a/lib/openscrapers/__init__.py
+++ b/lib/openscrapers/__init__.py
@@ -28,25 +28,26 @@ def sources(specified_folders=None, debug=False):
 			for loader, module_name, is_pkg in pkgutil.walk_packages([os.path.join(sourceFolderLocation, i)]):
 				if is_pkg:
 					continue
-				try:
-					module = loader.find_module(module_name).load_module(module_name)
-					sourceDict.append((module_name, module.source()))
-				except Exception as e:
-					if debug:
-						print('Error:Loading module: %s | %s ' % (module_name, e))
-					pass
-		return enabledHosters(sourceDict)
+				if enabledCheck(module_name):
+					try:
+						module = loader.find_module(module_name).load_module(module_name)
+						sourceDict.append((module_name, module.source()))
+					except Exception as e:
+						if debug:
+							print('Error:Loading module: %s | %s ' % (module_name, e))
+						pass
+		return sourceDict
 	except:
 		return []
 
 
-def enabledHosters(sourceDict, function=False):
+def enabledCheck(module_name):
 	if __addon__ is not None:
-		enabledHosts = [i[0] for i in sourceDict if __addon__.getSetting('provider.' + i[0].split('_')[0]) == 'true']
-		returnedHosts = [i for i in sourceDict if i[0] in enabledHosts]
-	else:
-		return sourceDict
-	return returnedHosts
+		if __addon__.getSetting('provider.' + module_name) == 'true':
+			return True
+		else:
+			return False
+	return True
 
 
 def providerSources():


### PR DESCRIPTION
This change will mean only enabled scrapers will import and be added to the sourceDict.

Previous implementation would import ALL available scrapers, add them to the sourceDict, and then remove the ones not enabled.

I have seen a slow down in starting the scrapers in the last few days. This should help, even if just a little bit..