### PR TITLE
More Py3 changes

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.module.openscrapers" name="OpenScrapers Module" version="0.0.2.006" provider-name="Addons4Kodi">
+<addon id="script.module.openscrapers" name="OpenScrapers Module" version="0.0.2.007" provider-name="Addons4Kodi">
 	<requires>
 		<import addon="xbmc.python" version="2.25.0" />
 		<import addon="script.module.beautifulsoup4" />
@@ -26,6 +26,8 @@
 			<screenshot></screenshot>
 		</assets>
 		<news>
+0.0.2.007
+- More work for Py3 compatibility
 0.0.2.006
 - Small fix to client module for Referer link
 - Added new free hoster WATCHSERIESTV

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.0.2.007
+- More work for Py3 compatibility
+
 0.0.2.006
 - Small fix to client module for Referer link
 - Added new free hoster WATCHSERIESTV

--- a/lib/openscrapers/modules/cache.py
+++ b/lib/openscrapers/modules/cache.py
@@ -32,7 +32,11 @@ def get(function, duration, *args):
 		cache_result = cache_get(key)
 		if cache_result:
 			if _is_cache_valid(cache_result['date'], duration):
-				return ast.literal_eval(cache_result['value'].encode('utf-8'))
+				try:
+					result = ast.literal_eval(cache_result['value'].encode('utf-8'))
+				except:
+					result = ast.literal_eval(cache_result['value'])
+				return result
 
 		fresh_result = repr(function(*args))
 		if not fresh_result:
@@ -42,7 +46,11 @@ def get(function, duration, *args):
 			return None
 
 		cache_insert(key, fresh_result)
-		return ast.literal_eval(fresh_result.encode('utf-8'))
+		try:
+			result = ast.literal_eval(fresh_result.encode('utf-8'))
+		except:
+			result = ast.literal_eval(fresh_result)
+		return result
 	except:
 		log_utils.error()
 		return None

--- a/lib/openscrapers/modules/client.py
+++ b/lib/openscrapers/modules/client.py
@@ -43,11 +43,16 @@ try:
 except ImportError:
 	from urllib.parse import urlencode, quote_plus
 
+try:
+    # Python 2 forward compatibility
+    range = xrange
+except NameError:
+    pass
+
 from openscrapers.modules import cache
 from openscrapers.modules import dom_parser
 from openscrapers.modules import log_utils
 from openscrapers.modules import workers
-
 
 def request(url, close=True, redirect=True, error=False, proxy=None, post=None, headers=None, mobile=False, XHR=False,
 			limit=None, referer=None, cookie=None, compression=True, output='', timeout='30', ignoreSsl=False,
@@ -135,7 +140,9 @@ def request(url, close=True, redirect=True, error=False, proxy=None, post=None, 
 
 		if isinstance(post, dict):
 			# Gets rid of the error: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)
-			for key, value in post.iteritems():
+			try: iter_items = post.iteritems()
+			except: iter_items = post.items()
+			for key, value in iter_items:
 				try:
 					post[key] = value.encode('utf-8')
 				except:
@@ -391,7 +398,10 @@ def _get_result(response, limit=None):
 
 def parseDOM(html, name='', attrs=None, ret=False):
 	if attrs:
-		attrs = dict((key, re.compile(value + ('$' if value else ''))) for key, value in attrs.iteritems())
+		try:
+			attrs = dict((key, re.compile(value + ('$' if value else ''))) for key, value in attrs.iteritems())
+		except:
+			attrs = dict((key, re.compile(value + ('$' if value else ''))) for key, value in attrs.items())
 	results = dom_parser.parse_dom(html, name, attrs, ret)
 
 	if ret:
@@ -417,7 +427,7 @@ def _replaceHTMLCodes(txt):
 
 def randomagent():
 	BR_VERS = [
-		['%s.0' % i for i in xrange(18, 50)],
+		['%s.0' % i for i in range(18, 50)],
 		['37.0.2062.103', '37.0.2062.120', '37.0.2062.124', '38.0.2125.101', '38.0.2125.104', '38.0.2125.111',
 		 '39.0.2171.71', '39.0.2171.95', '39.0.2171.99', '40.0.2214.93', '40.0.2214.111', '40.0.2214.115',
 		 '42.0.2311.90', '42.0.2311.135', '42.0.2311.152', '43.0.2357.81', '43.0.2357.124', '44.0.2403.155',
@@ -449,11 +459,11 @@ class cfcookie:
 	def get(self, netloc, ua, timeout):
 		threads = []
 
-		for i in range(0, 15):
+		for i in list(range(0, 15)):
 			threads.append(workers.Thread(self.get_cookie, netloc, ua, timeout))
 		[i.start() for i in threads]
 
-		for i in range(0, 30):
+		for i in list(range(0, 30)):
 			if self.cookie is not None:
 				return self.cookie
 			time.sleep(1)

--- a/lib/openscrapers/modules/dom_parser.py
+++ b/lib/openscrapers/modules/dom_parser.py
@@ -54,8 +54,11 @@ def __get_dom_elements(item, name, attrs):
 		this_list = re.findall(pattern, item, re.M | re.S | re.I)
 	else:
 		last_list = None
-
-		for key, value in attrs.iteritems():
+		try:
+			iter_items = attrs.iteritems()
+		except:
+			iter_items = attrs.items()
+		for key, value in iter_items:
 			value_is_regex = isinstance(value, re_type)
 			value_is_str = isinstance(value, basestring)
 			pattern = '''(<{tag}[^>]*\s{key}=(?P<delim>['"])(.*?)(?P=delim)[^>]*>)'''.format(tag=name, key=key)
@@ -105,10 +108,12 @@ def parse_dom(html, name='', attrs=None, req=False, exclude_comments=False):
 	if attrs is None:
 		attrs = {}
 	name = name.strip()
-
-	if isinstance(html, unicode) or isinstance(html, DomMatch):
+	try:
+		if isinstance(html, unicode):
+			html = [html]
+	except: pass
+	if isinstance(html, DomMatch):
 		html = [html]
-
 	elif isinstance(html, str):
 		try:
 			html = [html.decode("utf-8")]  # Replace with chardet thingy
@@ -117,9 +122,10 @@ def parse_dom(html, name='', attrs=None, req=False, exclude_comments=False):
 				html = [html.decode("utf-8", "replace")]
 			except:
 				html = [html]
+
 	elif not isinstance(html, list):
 		return ''
-
+	
 	if not name:
 		return ''
 

--- a/lib/openscrapers/modules/getSum.py
+++ b/lib/openscrapers/modules/getSum.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
 	from html.parser import HTMLParser
 
+from openscrapers.modules.utils import byteify
 from openscrapers.modules import log_utils
 
 headers = {
@@ -54,7 +55,7 @@ class GetSum(object):
 				links = re.compile(self._magnet_regex).findall(text)
 				if links:
 					for link in links:
-						link = str(replaceHTMLCodes(link).encode('utf-8').split('&tr')[0])
+						link = str(byteify(replaceHTMLCodes(link)).split('&tr')[0])
 						link = "magnet:" + link if not link.startswith('magnet') else link
 						if link in self.links:
 							continue
@@ -177,7 +178,7 @@ def get_video(text):
 	match = re.compile(pattern).findall(text)
 	links = []
 	for url in match:
-		links.append(url.encode('utf-8'))
+		links.append(byteify(url))
 	return links
 
 

--- a/lib/openscrapers/modules/jsunfuck.py
+++ b/lib/openscrapers/modules/jsunfuck.py
@@ -220,13 +220,19 @@ def cfunfuck(fuckedup):
 	fuck = re.findall(r's,t,o,p,b,r,e,a,k,i,n,g,f,\s*(\w+=).*?:\+?\(?(.*?)\)?\}', fuckedup)
 	fucks = re.findall(r'(\w+)\.\w+([\+\-\*\/]=)\+?\(?(.*?)\)?;', fuckedup)
 	endunfuck = fuck[0][0].split('=')[0]
-	unfuck = JSUnfuck(fuck[0][1]).decode()
+	try:
+		unfuck = JSUnfuck(fuck[0][1]).decode()
+	except:
+		unfuck = JSUnfuck(fuck[0][1])
 	unfuck = re.sub(r'[\(\)]', '', unfuck)
 	unfuck = fuck[0][0] + unfuck
 	exec (unfuck)
 
 	for fucker in fucks:
-		unfucker = JSUnfuck(fucker[2]).decode()
+		try:
+			unfucker = JSUnfuck(fucker[2]).decode()
+		except:
+			unfucker = JSUnfuck(fucker[2])
 		unfucker = re.sub(r'[\(\)]', '', unfucker)
 		unfucker = fucker[0] + fucker[1] + unfucker
 		exec (unfucker)
@@ -238,7 +244,10 @@ def main():
 	with open(sys.argv[1]) as f:
 		start_js = f.read()
 
-	print JSUnfuck(start_js).decode()
+	try:
+		print JSUnfuck(start_js).decode()
+	except:
+		print JSUnfuck(start_js)
 
 
 if __name__ == '__main__':

--- a/lib/openscrapers/modules/log_utils.py
+++ b/lib/openscrapers/modules/log_utils.py
@@ -35,8 +35,8 @@ def log(msg, caller=None, level=LOGNOTICE):
 	debug_enabled = control.setting('debug.enabled')
 	debug_log = control.setting('debug.location')
 
-	print DEBUGPREFIX + ' Debug Enabled?: ' + str(debug_enabled)
-	print DEBUGPREFIX + ' Debug Log?: ' + str(debug_log)
+	print( DEBUGPREFIX + ' Debug Enabled?: ' + str(debug_enabled))
+	print( DEBUGPREFIX + ' Debug Log?: ' + str(debug_log))
 
 	if control.setting('debug.enabled') != 'true':
 		return
@@ -50,9 +50,11 @@ def log(msg, caller=None, level=LOGNOTICE):
 
 		if caller is not None and level == LOGERROR:
 			msg = 'From func name: %s.%s() Line # :%s\n                       msg : %s'%(caller[0], caller[1], caller[2], msg)
-
-		if isinstance(msg, unicode):
-			msg = '%s (ENCODED)' % (msg.encode('utf-8'))
+		try:
+			if isinstance(msg, unicode):
+				msg = '%s (ENCODED)' % (msg.encode('utf-8'))
+		except:
+			pass
 
 		if not control.setting('debug.location') == '0':
 			log_file = os.path.join(LOGPATH, 'openscrapers.log')

--- a/lib/openscrapers/modules/regex.py
+++ b/lib/openscrapers/modules/regex.py
@@ -23,13 +23,14 @@ except ImportError:
 import xbmc
 import xbmcaddon
 
-profile = functions_dir = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile').decode('utf-8'))
+profile = functions_dir = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
 
 try:
 	from sqlite3 import dbapi2 as database
 except:
 	from pysqlite2 import dbapi2 as database
 
+from openscrapers.modules.utils import byteify
 from openscrapers.modules import client
 from openscrapers.modules import control
 
@@ -93,7 +94,7 @@ def resolve(regex):
 
 		url = regex.split('<regex>', 1)[0].strip()
 		url = client.replaceHTMLCodes(url)
-		url = url.encode('utf-8')
+		url = byteify(url)
 
 		r = getRegexParsed(regexs, url)
 

--- a/lib/openscrapers/modules/source_utils.py
+++ b/lib/openscrapers/modules/source_utils.py
@@ -273,7 +273,10 @@ def strip_domain(url):
 		if url.lower().startswith('http') or url.startswith('/'):
 			url = re.findall('(?://.+?|)(/.+)', url)[0]
 		url = client.replaceHTMLCodes(url)
-		url = url.encode('utf-8')
+		try:
+			url = url.encode('utf-8')
+		except:
+			pass
 		return url
 	except:
 		log_utils.error()

--- a/lib/openscrapers/modules/workers.py
+++ b/lib/openscrapers/modules/workers.py
@@ -5,12 +5,8 @@
 
 import threading
 
-
 class Thread(threading.Thread):
 	def __init__(self, target, *args):
 		self._target = target
 		self._args = args
-		threading.Thread.__init__(self)
-
-	def run(self):
-		self._target(*self._args)
+		threading.Thread.__init__(self, target=self._target, args=self._args)

--- a/lib/openscrapers/sources_openscrapers/__init__.py
+++ b/lib/openscrapers/sources_openscrapers/__init__.py
@@ -2,16 +2,16 @@
 
 import os.path
 
-import de
-import en
-import en_DebridOnly
-import en_Torrent
-import es
-import fr
-import gr
-import ko
-import pl
-import ru
+from . import de
+from . import en
+from . import en_DebridOnly
+from . import en_Torrent
+from . import es
+from . import fr
+from . import gr
+from . import ko
+from . import pl
+from . import ru
 
 
 scraper_source = os.path.dirname(__file__)
@@ -32,8 +32,12 @@ torrent_providers = en_Torrent.__all__
 ##--Paid Debrid(Debrid and Torrents)--##
 paid_providers = {'en_DebridOnly': debrid_providers, 'en_Torrent': torrent_providers}
 all_paid_providers = []
-for key, value in paid_providers.iteritems():
-	all_paid_providers += value
+try:
+	for key, value in paid_providers.iteritems():
+		all_paid_providers += value
+except:
+	for key, value in paid_providers.items():
+		all_paid_providers += value
 
 ##--Foreign Providers--##
 german_providers = de.__all__
@@ -49,8 +53,12 @@ foreign_providers = {'de': german_providers, 'es': spanish_providers, 'fr': fren
                      'ko': korean_providers,
                      'pl': polish_providers, 'ru': russian_providers}
 all_foreign_providers = []
-for key, value in foreign_providers.iteritems():
-	all_foreign_providers += value
+try:
+	for key, value in foreign_providers.iteritems():
+		all_foreign_providers += value
+except:
+	for key, value in foreign_providers.items():
+		all_foreign_providers += value
 
 ##--All Providers--##
 total_providers = {'en': hoster_providers, 'en_Debrid': debrid_providers, 'en_Torrent': torrent_providers,
@@ -58,5 +66,9 @@ total_providers = {'en': hoster_providers, 'en_Debrid': debrid_providers, 'en_To
                    'ko': korean_providers,
                    'pl': polish_providers, 'ru': russian_providers}
 all_providers = []
-for key, value in total_providers.iteritems():
-	all_providers += value
+try:
+	for key, value in total_providers.iteritems():
+		all_providers += value
+except:
+	for key, value in total_providers.items():
+		all_providers += value

--- a/lib/openscrapers/sources_openscrapers/de/animebase.py
+++ b/lib/openscrapers/sources_openscrapers/de/animebase.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -55,7 +58,7 @@ class source:
 					aliases):
 				if url: break
 				url = self.__search(title)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
@@ -64,10 +67,10 @@ class source:
 			if not url:
 				return
 			episode = tvmaze.tvMaze().episodeAbsoluteNumber(tvdb, int(season), int(episode))
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			data.update({'episode': episode})
-			return urllib.urlencode(data)
+			return urlencode(data)
 		except:
 			return
 
@@ -76,11 +79,11 @@ class source:
 		try:
 			if not url:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			url = data.get('url')
 			episode = int(data.get('episode', 1))
-			r = self.scraper.get(urlparse.urljoin(self.base_link, url)).content
+			r = self.scraper.get(urljoin(self.base_link, url)).content
 			r = {'': dom_parser.parse_dom(r, 'div', attrs={'id': 'gerdub'}),
 			     'subbed': dom_parser.parse_dom(r, 'div', attrs={'id': 'gersub'})}
 			for info, data in r.iteritems():
@@ -103,7 +106,7 @@ class source:
 
 	def resolve(self, url):
 		try:
-			if not url.startswith('http'): url = urlparse.urljoin(self.base_link, url)
+			if not url.startswith('http'): url = urljoin(self.base_link, url)
 			if self.base_link in url:
 				r = self.scraper.get(url).content
 				r = dom_parser.parse_dom(r, 'meta', req='content')[0]
@@ -118,7 +121,7 @@ class source:
 	def __search(self, title):
 		try:
 			t = cleantitle.get(title)
-			r = self.scraper.get(urlparse.urljoin(self.base_link, self.search_link),
+			r = self.scraper.get(urljoin(self.base_link, self.search_link),
 			                     post={'suchbegriff': title}).content
 			r = dom_parser.parse_dom(r, 'a', attrs={'class': 'ausgabe_1'}, req='href')
 			r = [(i.attrs['href'], i.content) for i in r]

--- a/lib/openscrapers/sources_openscrapers/de/animeloads.py
+++ b/lib/openscrapers/sources_openscrapers/de/animeloads.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import anilist
 from openscrapers.modules import cleantitle
@@ -51,7 +54,7 @@ class source:
 		try:
 			url = self.__search(
 				[title, localtitle, anilist.getAlternativTitle(title)] + source_utils.aliases_to_array(aliases), year)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
@@ -59,7 +62,7 @@ class source:
 		try:
 			url = self.__search([tvshowtitle, localtvshowtitle, tvmaze.tvMaze().showLookup('thetvdb', tvdb).get(
 				'name')] + source_utils.aliases_to_array(aliases), year)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
@@ -68,10 +71,10 @@ class source:
 			if not url:
 				return
 			episode = tvmaze.tvMaze().episodeAbsoluteNumber(tvdb, int(season), int(episode))
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			data.update({'episode': episode})
-			return urllib.urlencode(data)
+			return urlencode(data)
 		except:
 			return
 
@@ -80,11 +83,11 @@ class source:
 		try:
 			if not url:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			url = data.get('url')
 			episode = int(data.get('episode', 1))
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'streams'})
 			rels = dom_parser.parse_dom(r, 'ul', attrs={'class': 'nav'})
 			rels = dom_parser.parse_dom(rels, 'li')
@@ -144,8 +147,8 @@ class source:
 
 	def __search(self, titles, year):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.query(titles[0])))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.query(titles[0])))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'main'})

--- a/lib/openscrapers/sources_openscrapers/de/cine.py
+++ b/lib/openscrapers/sources_openscrapers/de/cine.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import client
 from openscrapers.modules import source_utils
@@ -46,7 +49,7 @@ class source:
 
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
-			return urllib.urlencode({'imdb': imdb})
+			return urlencode({'imdb': imdb})
 		except:
 			return
 
@@ -56,10 +59,10 @@ class source:
 			if url is None:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
-			data = urllib.urlencode({'ID': re.sub('[^0-9]', '', str(data['imdb'])), 'lang': 'de'})
-			data = client.request(urlparse.urljoin(self.base_link, self.request_link), post=data, XHR=True)
+			data = urlencode({'ID': re.sub('[^0-9]', '', str(data['imdb'])), 'lang': 'de'})
+			data = client.request(urljoin(self.base_link, self.request_link), post=data, XHR=True)
 			data = json.loads(data)
 			data = [(i, data['links'][i]) for i in data['links'] if 'links' in data]
 			data = [(i[0], i[1][0], (i[1][1:])) for i in data]
@@ -79,7 +82,7 @@ class source:
 
 	def resolve(self, url):
 		try:
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			url = client.request(url, output='geturl')
 			if self.out_link not in url:
 				return url

--- a/lib/openscrapers/sources_openscrapers/de/ddl.py
+++ b/lib/openscrapers/sources_openscrapers/de/ddl.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import client
 from openscrapers.modules import source_utils
@@ -48,7 +51,7 @@ class source:
 			url = self.__get_direct_url(imdb)
 			if not url:
 				return
-			return urllib.urlencode({'url': url})
+			return urlencode({'url': url})
 		except:
 			return
 
@@ -67,7 +70,7 @@ class source:
 			j = [v['info'] for k, v in j.items()]
 			j = [(i['nr'], i['staffel'], i['sid']) for i in j]
 			j = [(i[2]) for i in j if int(i[0]) == int(episode) and int(i[1]) == int(season)][0]
-			return urllib.urlencode({'url': url, 'sid': j})
+			return urlencode({'url': url, 'sid': j})
 		except:
 			return
 
@@ -77,7 +80,7 @@ class source:
 			if url is None:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			j = self.__get_json(data['url'])
@@ -111,7 +114,7 @@ class source:
 
 	def __get_direct_url(self, imdb):
 		try:
-			query = urlparse.urljoin(self.base_link, self.search_link % imdb)
+			query = urljoin(self.base_link, self.search_link % imdb)
 			r = client.request(query, output='geturl')
 			if self.search_link in r: return
 			return r

--- a/lib/openscrapers/sources_openscrapers/de/filmpalast.py
+++ b/lib/openscrapers/sources_openscrapers/de/filmpalast.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -59,7 +62,7 @@ class source:
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle,
 			       'aliases': aliases, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -68,7 +71,7 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			title = data['localtvshowtitle']
 			title += ' S%02dE%02d' % (int(season), int(episode))
@@ -88,7 +91,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			r = self.scraper.get(query).content
 			quality = dom_parser.parse_dom(r, 'span', attrs={'id': 'release_text'})[0].content.split('&nbsp;')[0]
 			quality, info = source_utils.get_release_quality(quality)
@@ -111,8 +114,8 @@ class source:
 		try:
 			h_url = []
 			for id in url:
-				query = urlparse.urljoin(self.base_link, self.stream_link % id)
-				r = self.scraper.get(query, XHR=True, post=urllib.urlencode({'streamID': id})).content
+				query = urljoin(self.base_link, self.stream_link % id)
+				r = self.scraper.get(query, XHR=True, post=urlencode({'streamID': id})).content
 				r = json.loads(r)
 				if 'error' in r and r['error'] == '0' and 'url' in r:
 					h_url.append(r['url'])
@@ -123,8 +126,8 @@ class source:
 
 	def __search(self, titles):
 		try:
-			query = self.search_link % (urllib.quote_plus(titles[0]))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(titles[0]))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = self.scraper.get(query).content
 			r = dom_parser.parse_dom(r, 'article')

--- a/lib/openscrapers/sources_openscrapers/de/foxx.py
+++ b/lib/openscrapers/sources_openscrapers/de/foxx.py
@@ -29,8 +29,11 @@
 import base64
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import anilist
 from openscrapers.modules import cache
@@ -79,7 +82,7 @@ class source:
 		try:
 			if not url:
 				return
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			url = client.request(url, output='geturl')
 			if season == 1 and episode == 1:
 				season = episode = ''
@@ -96,7 +99,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url, output='extended')
 			headers = r[3]
 			headers.update({'Cookie': r[2].get('Set-Cookie'), 'Referer': self.base_link})
@@ -118,7 +121,7 @@ class source:
 				try:
 					i = re.sub('\[.+?\]|\[/.+?\]', '', i)
 					i = client.replaceHTMLCodes(i)
-					if '/play/' in i: i = urlparse.urljoin(self.base_link, i)
+					if '/play/' in i: i = urljoin(self.base_link, i)
 					if self.domains[0] in i:
 						i = client.request(i, headers=headers, referer=url)
 						for x in re.findall('''\(["']?(.*)["']?\)''', i):
@@ -171,8 +174,8 @@ class source:
 	def __search(self, titles, year):
 		try:
 			n = cache.get(self.__get_nonce, 24)
-			query = self.search_link % (urllib.quote_plus(cleantitle.query(titles[0])), n)
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.query(titles[0])), n)
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
 			r = client.request(query)

--- a/lib/openscrapers/sources_openscrapers/de/hdstreams.py
+++ b/lib/openscrapers/sources_openscrapers/de/hdstreams.py
@@ -29,8 +29,11 @@
 import base64
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cache
 from openscrapers.modules import cleantitle
@@ -51,14 +54,14 @@ class source:
 			url = self.__search([localtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and title != localtitle: url = self.__search([title] + source_utils.aliases_to_array(aliases),
 			                                                        year)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,7 +70,7 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			tvshowtitle = data['tvshowtitle']
 			localtvshowtitle = data['localtvshowtitle']
@@ -77,7 +80,7 @@ class source:
 			url = self.__search([localtvshowtitle] + aliases, year, season)
 			if not url and tvshowtitle != localtvshowtitle: url = self.__search([tvshowtitle] + aliases, year, season)
 			if not url: return
-			return urllib.urlencode({'url': url, 'episode': episode})
+			return urlencode({'url': url, 'episode': episode})
 		except:
 			return
 
@@ -86,9 +89,9 @@ class source:
 		try:
 			if not url:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
-			url = urlparse.urljoin(self.base_link, data.get('url'))
+			url = urljoin(self.base_link, data.get('url'))
 			episode = data.get('episode')
 			r = client.request(url)
 			aj = self.__get_ajax_object(r)

--- a/lib/openscrapers/sources_openscrapers/de/horrorkino.py
+++ b/lib/openscrapers/sources_openscrapers/de/horrorkino.py
@@ -27,7 +27,9 @@
 '''
 
 import re
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -58,7 +60,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 			r = re.findall('''vicode\s*=\s*["'](.*?)["'];''', r)[0].decode('string_escape')
 			r = dom_parser.parse_dom(r, 'iframe', req='src')
 			r = [i.attrs['src'] for i in r]
@@ -79,7 +81,7 @@ class source:
 		try:
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
-			r = client.request(urlparse.urljoin(self.base_link, self.search_link),
+			r = client.request(urljoin(self.base_link, self.search_link),
 			                   post={'query': cleantitle.query(titles[0])})
 			r = dom_parser.parse_dom(r, 'li', attrs={'class': 'entTd'})
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 've-screen'}, req='title')

--- a/lib/openscrapers/sources_openscrapers/de/movie2k-ag.py
+++ b/lib/openscrapers/sources_openscrapers/de/movie2k-ag.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -58,7 +61,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'player'})
 			r = dom_parser.parse_dom(r, 'iframe', req='src')
@@ -90,8 +93,8 @@ class source:
 
 	def __search(self, titles):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.query(titles[0])))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.query(titles[0])))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'nag'})

--- a/lib/openscrapers/sources_openscrapers/de/movie2k.py
+++ b/lib/openscrapers/sources_openscrapers/de/movie2k.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -57,7 +60,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'tab-plot_german'})
 			r = dom_parser.parse_dom(r, 'tbody')
@@ -84,8 +87,8 @@ class source:
 
 	def __search(self, titles):
 		try:
-			query = self.search_link % (urllib.quote_plus(urllib.quote_plus(cleantitle.query(titles[0]))))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(quote_plus(cleantitle.query(titles[0]))))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'ul', attrs={'class': 'coverBox'})

--- a/lib/openscrapers/sources_openscrapers/de/movie4k.py
+++ b/lib/openscrapers/sources_openscrapers/de/movie4k.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urlparse, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cache
 from openscrapers.modules import cleantitle
@@ -66,7 +69,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = r.replace('\\"', '"')
 			links = dom_parser.parse_dom(r, 'tr', attrs={'id': 'tablemoviesindex2'})
@@ -79,7 +82,7 @@ class source:
 					if not valid: continue
 					url = dom_parser.parse_dom(i, 'a', req='href')[0].attrs['href']
 					url = client.replaceHTMLCodes(url)
-					url = urlparse.urljoin(self.base_link, url)
+					url = urljoin(self.base_link, url)
 					url = url.encode('utf-8')
 					sources.append({'source': host, 'quality': 'SD', 'language': 'de', 'url': url, 'direct': False,
 					                'debridonly': False})
@@ -91,7 +94,7 @@ class source:
 
 	def resolve(self, url):
 		try:
-			h = urlparse.urlparse(url.strip().lower()).netloc
+			h = urlparse(url.strip().lower()).netloc
 			r = client.request(url)
 			r = r.rsplit('"underplayer"')[0].rsplit("'underplayer'")[0]
 			u = re.findall('\'(.+?)\'', r) + re.findall('\"(.+?)\"', r)
@@ -104,8 +107,8 @@ class source:
 
 	def __search(self, imdb, titles, year):
 		try:
-			q = self.search_link % urllib.quote_plus(cleantitle.query(titles[0]))
-			q = urlparse.urljoin(self.base_link, q)
+			q = self.search_link % quote_plus(cleantitle.query(titles[0]))
+			q = urljoin(self.base_link, q)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
 			r = client.request(q)
@@ -135,7 +138,7 @@ class source:
 			for i in match2[:5]:
 				try:
 					if match: url = match[0]; break
-					r = client.request(urlparse.urljoin(self.base_link, i))
+					r = client.request(urljoin(self.base_link, i))
 					r = re.findall('(tt\d+)', r)
 					if imdb in r: url = i; break
 				except:

--- a/lib/openscrapers/sources_openscrapers/de/movietown.py
+++ b/lib/openscrapers/sources_openscrapers/de/movietown.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -71,7 +74,7 @@ class source:
 			s = '/seasons/%s/episodes/%s' % (season, episode)
 			url = url.rstrip('/')
 			url = url + s
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			return url
 		except:
 			return
@@ -81,7 +84,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			r = self.scraper.get(query).content
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'ko-bind'})
 			r = dom_parser.parse_dom(r, 'table', attrs={'class': 'links-table'})
@@ -110,8 +113,8 @@ class source:
 
 	def __search(self, titles, year):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.query(titles[0] + ' ' + year)))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.query(titles[0] + ' ' + year)))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = self.scraper.get(query).content
 			r = dom_parser.parse_dom(r, 'figure', attrs={'class': 'pretty-figure'})

--- a/lib/openscrapers/sources_openscrapers/de/netzkino.py
+++ b/lib/openscrapers/sources_openscrapers/de/netzkino.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -59,7 +62,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			r = client.request(urlparse.urljoin(self.base_link, self.conf_link), XHR=True)
+			r = client.request(urljoin(self.base_link, self.conf_link), XHR=True)
 			r = json.loads(r).get('streamer')
 			r = client.request(r + '%s.mp4/master.m3u8' % url, XHR=True)
 			r = re.findall('RESOLUTION\s*=\s*\d+x(\d+).*?\n(http.*?)(?:\n|$)', r, re.IGNORECASE)
@@ -76,8 +79,8 @@ class source:
 
 	def __search(self, titles, imdb, year):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.query(titles[0])))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.query(titles[0])))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
 			r = client.request(query, XHR=True)

--- a/lib/openscrapers/sources_openscrapers/de/stream-to.py
+++ b/lib/openscrapers/sources_openscrapers/de/stream-to.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -66,7 +69,7 @@ class source:
 				return sources
 			# load player
 			query = self.get_player % (video_id)
-			query = urlparse.urljoin(self.base_link, query)
+			query = urljoin(self.base_link, query)
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'le-server'})
 			# for each hoster
@@ -96,7 +99,7 @@ class source:
 	def resolve(self, url):
 		try:
 			query = self.get_link % (url)
-			query = urlparse.urljoin(self.base_link, query)
+			query = urljoin(self.base_link, query)
 			r = client.request(query)
 			url = dom_parser.parse_dom(r, 'iframe', req='src')
 			url = url[0][0]['src']
@@ -106,8 +109,8 @@ class source:
 
 	def __search(self, titles):
 		try:
-			query = urlparse.urljoin(self.base_link, self.search_link)
-			post = urllib.urlencode({'keyword': titles[0]})
+			query = urljoin(self.base_link, self.search_link)
+			post = urlencode({'keyword': titles[0]})
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = client.request(query, post=post)
 			r = json.loads(r)

--- a/lib/openscrapers/sources_openscrapers/de/streamflix.py
+++ b/lib/openscrapers/sources_openscrapers/de/streamflix.py
@@ -27,8 +27,11 @@
 '''
 
 import json
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -51,7 +54,7 @@ class source:
 		try:
 			id = self.__search([localtitle] + source_utils.aliases_to_array(aliases))
 			if not id and title != localtitle: id = self.__search([title] + source_utils.aliases_to_array(aliases))
-			return urllib.urlencode({'id': id}) if id else None
+			return urlencode({'id': id}) if id else None
 		except:
 			return
 
@@ -60,7 +63,7 @@ class source:
 			id = self.__search([localtvshowtitle] + source_utils.aliases_to_array(aliases))
 			if not id and tvshowtitle != localtvshowtitle: id = self.__search(
 				[tvshowtitle] + source_utils.aliases_to_array(aliases))
-			return urllib.urlencode({'id': id}) if id else None
+			return urlencode({'id': id}) if id else None
 		except:
 			return
 
@@ -68,10 +71,10 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			data.update({'season': season, 'episode': episode})
-			return urllib.urlencode(data)
+			return urlencode(data)
 		except:
 			return
 
@@ -80,19 +83,19 @@ class source:
 		try:
 			if not url:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			id = data.get('id')
 			season = data.get('season')
 			episode = data.get('episode')
 			if season and episode:
-				r = client.request(urlparse.urljoin(self.base_link, self.get_episodes),
+				r = client.request(urljoin(self.base_link, self.get_episodes),
 				                   post={'series_id': id, 'mlang': 'de', 'season': season, 'episode': episode})
 				r = json.loads(r).get('episode_links', [])
 				r = [([i.get('id')], i.get('hostername')) for i in r]
 			else:
 				data.update({'lang': 'de'})
-				r = client.request(urlparse.urljoin(self.base_link, self.get_links), post=data)
+				r = client.request(urljoin(self.base_link, self.get_links), post=data)
 				r = json.loads(r).get('links', [])
 				r = [(i.get('ids'), i.get('hoster')) for i in r]
 			for link_ids, hoster in r:
@@ -108,7 +111,7 @@ class source:
 
 	def resolve(self, url):
 		try:
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			if self.base_link in url:
 				url = client.request(url, output='geturl')
 			return url
@@ -117,8 +120,8 @@ class source:
 
 	def __search(self, titles):
 		try:
-			query = self.search_link % urllib.quote_plus(cleantitle.query(titles[0]))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % quote_plus(cleantitle.query(titles[0]))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = client.request(query)
 			r = json.loads(r)

--- a/lib/openscrapers/sources_openscrapers/de/streamit.py
+++ b/lib/openscrapers/sources_openscrapers/de/streamit.py
@@ -28,8 +28,11 @@
 
 import base64
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin, urlparse
+except ImportError: from urllib.parse import parse_qs, urljoin, urlparse
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -51,7 +54,7 @@ class source:
 			url = self.__search([localtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and title != localtitle: url = self.__search([title] + source_utils.aliases_to_array(aliases),
 			                                                        year)
-			return urllib.urlencode({'url': url, 'imdb': re.sub('[^0-9]', '', imdb)}) if url else None
+			return urlencode({'url': url, 'imdb': re.sub('[^0-9]', '', imdb)}) if url else None
 		except:
 			return
 
@@ -60,7 +63,7 @@ class source:
 			url = self.__search([localtvshowtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and tvshowtitle != localtvshowtitle: url = self.__search(
 				[tvshowtitle] + source_utils.aliases_to_array(aliases), year)
-			return urllib.urlencode({'url': url, 'imdb': re.sub('[^0-9]', '', imdb)}) if url else None
+			return urlencode({'url': url, 'imdb': re.sub('[^0-9]', '', imdb)}) if url else None
 		except:
 			return
 
@@ -68,10 +71,10 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			data.update({'season': season, 'episode': episode})
-			return urllib.urlencode(data)
+			return urlencode(data)
 		except:
 			return
 
@@ -80,15 +83,15 @@ class source:
 		try:
 			if not url:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
-			url = urlparse.urljoin(self.base_link, data.get('url', ''))
+			url = urljoin(self.base_link, data.get('url', ''))
 			imdb = data.get('imdb')
 			season = data.get('season')
 			episode = data.get('episode')
 			if season and episode and imdb:
-				r = urllib.urlencode({'val': 's%se%s' % (season, episode), 'IMDB': imdb})
-				r = client.request(urlparse.urljoin(self.base_link, self.episode_link), XHR=True, post=r)
+				r = urlencode({'val': 's%se%s' % (season, episode), 'IMDB': imdb})
+				r = client.request(urljoin(self.base_link, self.episode_link), XHR=True, post=r)
 			else:
 				r = client.request(url)
 			l = dom_parser.parse_dom(r, 'select', attrs={'id': 'sel_sprache'})
@@ -103,7 +106,7 @@ class source:
 			for quality, urls in r:
 				for link in urls:
 					try:
-						data = urlparse.parse_qs(urlparse.urlparse(link).query, keep_blank_values=True)
+						data = parse_qs(urlparse(link).query, keep_blank_values=True)
 						if 'm' in data:
 							data = data.get('m')[0]
 							link = base64.b64decode(data)
@@ -126,8 +129,8 @@ class source:
 		try:
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
-			r = client.request(urlparse.urljoin(self.base_link, self.search_link),
-			                   post=urllib.urlencode({'val': cleantitle.query(titles[0])}), XHR=True)
+			r = client.request(urljoin(self.base_link, self.search_link),
+			                   post=urlencode({'val': cleantitle.query(titles[0])}), XHR=True)
 			r = dom_parser.parse_dom(r, 'li')
 			r = dom_parser.parse_dom(r, 'a', req='href')
 			r = [(i.attrs['href'], i.content, re.findall('\((\d{4})', i.content)) for i in r]

--- a/lib/openscrapers/sources_openscrapers/de/video4k.py
+++ b/lib/openscrapers/sources_openscrapers/de/video4k.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import client
 from openscrapers.modules import source_utils
@@ -45,13 +48,13 @@ class source:
 
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
-			return urllib.urlencode({'mID': re.sub('[^0-9]', '', imdb)})
+			return urlencode({'mID': re.sub('[^0-9]', '', imdb)})
 		except:
 			return
 
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
-			return urllib.urlencode({'mID': re.sub('[^0-9]', '', imdb)})
+			return urlencode({'mID': re.sub('[^0-9]', '', imdb)})
 		except:
 			return
 
@@ -59,7 +62,7 @@ class source:
 		try:
 			if url is None:
 				return
-			return urllib.urlencode({'mID': re.sub('[^0-9]', '', imdb), 'season': season, 'episode': episode})
+			return urlencode({'mID': re.sub('[^0-9]', '', imdb), 'season': season, 'episode': episode})
 		except:
 			return
 
@@ -68,11 +71,11 @@ class source:
 		try:
 			if url is None:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			data.update({'raw': 'true', 'language': 'de'})
-			data = urllib.urlencode(data)
-			data = client.request(urlparse.urljoin(self.base_link, self.request_link), post=data)
+			data = urlencode(data)
+			data = client.request(urljoin(self.base_link, self.request_link), post=data)
 			data = json.loads(data)
 			data = [i[1] for i in data[1].items()]
 			data = [(i['name'].lower(), i['links']) for i in data]

--- a/lib/openscrapers/sources_openscrapers/de/view4u.py
+++ b/lib/openscrapers/sources_openscrapers/de/view4u.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -49,14 +52,14 @@ class source:
 			url = self.__search([localtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and title != localtitle: url = self.__search([title] + source_utils.aliases_to_array(aliases),
 			                                                        year)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle, 'aliases': aliases, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -65,7 +68,7 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			tvshowtitle = data['tvshowtitle']
 			localtvshowtitle = data['localtvshowtitle']
@@ -74,7 +77,7 @@ class source:
 			if not url and tvshowtitle != localtvshowtitle: url = self.__search([tvshowtitle] + aliases, data['year'],
 			                                                                    season)
 			if not url: return
-			return urllib.urlencode({'url': url, 'episode': episode})
+			return urlencode({'url': url, 'episode': episode})
 		except:
 			return
 
@@ -83,9 +86,9 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
-			url = urlparse.urljoin(self.base_link, data.get('url', ''))
+			url = urljoin(self.base_link, data.get('url', ''))
 			episode = data.get('episode')
 			r = client.request(url)
 			r = r.replace('\n', ' ')
@@ -115,8 +118,8 @@ class source:
 
 	def __search(self, titles, year, season='0'):
 		try:
-			query = self.search_link % urllib.quote_plus(cleantitle.query(titles[0]))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % quote_plus(cleantitle.query(titles[0]))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
 			r = client.request(query)

--- a/lib/openscrapers/sources_openscrapers/de/view4u2.py
+++ b/lib/openscrapers/sources_openscrapers/de/view4u2.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -49,14 +52,14 @@ class source:
 			url = self.__search([localtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and title != localtitle: url = self.__search([title] + source_utils.aliases_to_array(aliases),
 			                                                        year)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle, 'aliases': aliases, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -65,7 +68,7 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			tvshowtitle = data['tvshowtitle']
 			localtvshowtitle = data['localtvshowtitle']
@@ -74,7 +77,7 @@ class source:
 			if not url and tvshowtitle != localtvshowtitle: url = self.__search([tvshowtitle] + aliases, data['year'],
 			                                                                    season)
 			if not url: return
-			return urllib.urlencode({'url': url, 'episode': episode})
+			return urlencode({'url': url, 'episode': episode})
 		except:
 			return
 
@@ -83,9 +86,9 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
-			url = urlparse.urljoin(self.base_link, data.get('url', ''))
+			url = urljoin(self.base_link, data.get('url', ''))
 			episode = data.get('episode')
 			r = client.request(url)
 			r = r.replace('\n', ' ')
@@ -115,8 +118,8 @@ class source:
 
 	def __search(self, titles, year, season='0'):
 		try:
-			query = self.search_link % urllib.quote_plus(cleantitle.query(titles[0]))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % quote_plus(cleantitle.query(titles[0]))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
 			r = client.request(query)

--- a/lib/openscrapers/sources_openscrapers/en/5movies.py
+++ b/lib/openscrapers/sources_openscrapers/en/5movies.py
@@ -11,8 +11,11 @@
 
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -43,7 +46,7 @@ class source:
 		try:
 			aliases.append({'country': 'us', 'title': title})
 			url = {'imdb': imdb, 'title': title, 'year': year, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -53,7 +56,7 @@ class source:
 		try:
 			aliases.append({'country': 'us', 'title': tvshowtitle})
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -63,10 +66,10 @@ class source:
 		try:
 			if url == None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -74,7 +77,7 @@ class source:
 
 	def _search(self, title, year, aliases, headers):
 		try:
-			q = urlparse.urljoin(self.base_link, self.search_link % urllib.quote_plus(cleantitle.getsearch(title)))
+			q = urljoin(self.base_link, self.search_link % quote_plus(cleantitle.getsearch(title)))
 			r = client.request(q)
 			r = client.parseDOM(r, 'div', attrs={'class':'ml-img'})
 			r = zip(client.parseDOM(r, 'a', ret='href'), client.parseDOM(r, 'img', ret='alt'))
@@ -90,7 +93,7 @@ class source:
 			sources = []
 			if url == None:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			aliases = eval(data['aliases'])
 			headers = {}
@@ -105,7 +108,7 @@ class source:
 				episode = None
 				year = data['year']
 				url = self._search(data['title'], data['year'], aliases, headers)
-			url = url if 'http' in url else urlparse.urljoin(self.base_link, url)
+			url = url if 'http' in url else urljoin(self.base_link, url)
 			result = client.request(url);
 			result = client.parseDOM(result, 'li', attrs={'class':'link-button'})
 			links = client.parseDOM(result, 'a', ret='href')
@@ -115,7 +118,7 @@ class source:
 					#break
 				try:
 					l = l.split('=')[1]
-					l = urlparse.urljoin(self.base_link, self.video_link % l)
+					l = urljoin(self.base_link, self.video_link % l)
 					result = client.request(l, post={}, headers={'Referer':url})
 					u = result if 'http' in result else 'http:' + result
 					if ' href' in u:
@@ -131,7 +134,10 @@ class source:
 						if not valid:
 							continue
 						try:
-							u.decode('utf-8')
+							try:
+								u.decode('utf-8')
+							except:
+								pass
 							sources.append({'source': hoster, 'quality': '720p', 'language': 'en', 'url': u, 'direct': False, 'debridonly': False})
 							i+=1
 						except:

--- a/lib/openscrapers/sources_openscrapers/en/cartoonhd.py
+++ b/lib/openscrapers/sources_openscrapers/en/cartoonhd.py
@@ -29,8 +29,11 @@ import base64
 import json
 import re
 import time
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote, unquote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -50,7 +53,7 @@ class source:
 		try:
 			aliases.append({'country': 'us', 'title': title})
 			url = {'imdb': imdb, 'title': title, 'year': year, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -60,7 +63,7 @@ class source:
 		try:
 			aliases.append({'country': 'us', 'title': tvshowtitle})
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -70,10 +73,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -116,7 +119,7 @@ class source:
 			sources = []
 			if url is None:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
 			imdb = data['imdb']
@@ -145,18 +148,18 @@ class source:
 				auth = re.findall('__utmx=(.+)', cookie)[0].split(';')[0]
 			except:
 				auth = 'false'
-			auth = 'Bearer %s' % urllib.unquote_plus(auth)
+			auth = 'Bearer %s' % unquote_plus(auth)
 			headers['Authorization'] = auth
 			headers['Referer'] = url
 			u = '/ajax/vsozrflxcw.php'
 			self.base_link = client.request(self.base_link, headers=headers, output='geturl')
-			u = urlparse.urljoin(self.base_link, u)
+			u = urljoin(self.base_link, u)
 			action = 'getEpisodeEmb' if '/episode/' in url else 'getMovieEmb'
-			elid = urllib.quote(base64.encodestring(str(int(time.time()))).strip())
+			elid = quote(base64.encodestring(str(int(time.time()))).strip())
 			token = re.findall("var\s+tok\s*=\s*'([^']+)", result)[0]
 			idEl = re.findall('elid\s*=\s*"([^"]+)', result)[0]
 			post = {'action': action, 'idEl': idEl, 'token': token, 'nopop': '', 'elid': elid}
-			post = urllib.urlencode(post)
+			post = urlencode(post)
 			cookie += ';%s=%s' % (idEl, elid)
 			headers['Cookie'] = cookie
 			r = client.request(u, post=post, headers=headers, cookie=cookie, XHR=True)

--- a/lib/openscrapers/sources_openscrapers/en/extramovies.py
+++ b/lib/openscrapers/sources_openscrapers/en/extramovies.py
@@ -27,8 +27,11 @@
 
 import base64
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -50,7 +53,7 @@ class source:
 		try:
 			aliases.append({'country': 'us', 'title': title})
 			url = {'imdb': imdb, 'title': title, 'year': year, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except Exception:
 			source_utils.scraper_error('EXTRAMOVIES')
@@ -61,7 +64,7 @@ class source:
 		try:
 			aliases.append({'country': 'us', 'title': tvshowtitle})
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except Exception:
 			source_utils.scraper_error('EXTRAMOVIES')
@@ -72,10 +75,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except Exception:
 			source_utils.scraper_error('EXTRAMOVIES')
@@ -90,12 +93,12 @@ class source:
 			if url is None:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
 
-			url = urlparse.urljoin(self.base_link, self.search_link % urllib.quote_plus(cleantitle.query(title)))
+			url = urljoin(self.base_link, self.search_link % quote_plus(cleantitle.query(title)))
 
 			if 'tvshowtitle' in data:
 				html = self.scraper.get(url).content

--- a/lib/openscrapers/sources_openscrapers/en/filepursuit.py
+++ b/lib/openscrapers/sources_openscrapers/en/filepursuit.py
@@ -25,10 +25,13 @@
 '''
 
 import re
-import urllib
-import urlparse
 import requests
 import json
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import control
 from openscrapers.modules import client
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('FILEPURSUIT')
@@ -58,7 +61,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('FILEPURSUIT')
@@ -69,10 +72,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('FILEPURSUIT')
@@ -91,7 +94,7 @@ class source:
 			if url is None:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -103,8 +106,8 @@ class source:
 			query = '%s %s' % (self.title, self.hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url, headers=headers)

--- a/lib/openscrapers/sources_openscrapers/en/filmxy.py
+++ b/lib/openscrapers/sources_openscrapers/en/filmxy.py
@@ -25,7 +25,9 @@
 '''
 
 import re
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -44,7 +46,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			title = cleantitle.geturl(title)
-			url = urlparse.urljoin(self.base_link, (self.search_link % (title, year)))
+			url = urljoin(self.base_link, (self.search_link % (title, year)))
 			return url
 		except:
 			source_utils.scraper_error('FILEXY')

--- a/lib/openscrapers/sources_openscrapers/en/gowatchseries.py
+++ b/lib/openscrapers/sources_openscrapers/en/gowatchseries.py
@@ -26,8 +26,11 @@
 '''
 
 import json
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('GOWATCHSERIES')
@@ -58,7 +61,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('GOWATCHSERIES')
@@ -69,10 +72,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('GOWATCHSERIES')
@@ -85,7 +88,7 @@ class source:
 			if url is None:
 				return sources
 			if not str(url).startswith('http'):
-				data = urlparse.parse_qs(url)
+				data = parse_qs(url)
 				data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 				title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
 				if 'season' in data:
@@ -98,8 +101,8 @@ class source:
 				headers = r[3];
 				result = r[0]
 				headers['Cookie'] = cookie
-				query = urlparse.urljoin(self.base_link,
-				                         self.search_link % urllib.quote_plus(cleantitle.getsearch(title)))
+				query = urljoin(self.base_link,
+				                         self.search_link % quote_plus(cleantitle.getsearch(title)))
 				r = client.request(query, headers=headers, XHR=True)
 				r = json.loads(r)['content']
 				r = zip(client.parseDOM(r, 'a', ret='href'), client.parseDOM(r, 'a'))

--- a/lib/openscrapers/sources_openscrapers/en/iwaatch.py
+++ b/lib/openscrapers/sources_openscrapers/en/iwaatch.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote, quote_plus
+except ImportError: from urllib.parse import urlencode, quote, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -47,7 +50,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except BaseException:
 			source_utils.scraper_error('IWAATCH')
@@ -60,7 +63,7 @@ class source:
 			if not url:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			title = data['title']
 			year = data['year']
@@ -69,8 +72,8 @@ class source:
 			query = '%s' % data['title']
 			query = re.sub(r'(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', ' ', query)
 
-			url = self.search_link.format(urllib.quote_plus(query))
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link.format(quote_plus(query))
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url)
@@ -89,7 +92,7 @@ class source:
 
 			for link, label in streams:
 				quality = source_utils.get_release_quality(label, label)[0]
-				link += '|User-Agent=%s&Referer=%s' % (urllib.quote(client.agent()), item)
+				link += '|User-Agent=%s&Referer=%s' % (quote(client.agent()), item)
 				sources.append({'source': 'direct', 'quality': quality, 'info': '', 'language': 'en', 'url': link,
 				                'direct': True, 'debridonly': False})
 

--- a/lib/openscrapers/sources_openscrapers/en/iwannawatch.py
+++ b/lib/openscrapers/sources_openscrapers/en/iwannawatch.py
@@ -10,7 +10,9 @@
 
 import re
 import requests
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import source_utils
@@ -29,7 +31,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			search_id = cleantitle.getsearch(title)
-			url = urlparse.urljoin(self.base_link, self.search_link)
+			url = urljoin(self.base_link, self.search_link)
 			url = url  % (search_id.replace(' ', '+').replace('-', '+').replace('++', '+'), year)
 			headers = {'User-Agent': self.User_Agent}
 			search_results = requests.get(url, headers=headers, timeout=10).content

--- a/lib/openscrapers/sources_openscrapers/en/moviescouch.py
+++ b/lib/openscrapers/sources_openscrapers/en/moviescouch.py
@@ -25,7 +25,9 @@
 '''
 
 import re
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import client
 from openscrapers.modules import cleantitle
@@ -44,7 +46,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			search_id = cleantitle.getsearch(title)
-			url = urlparse.urljoin(self.base_link, self.search_link)
+			url = urljoin(self.base_link, self.search_link)
 			url = url % (search_id.replace(':', ' ').replace(' ', '+'))
 			search_results = client.request(url)
 			match = re.compile('<article id=.+?href="(.+?)" title="(.+?)"',re.DOTALL).findall(search_results)

--- a/lib/openscrapers/sources_openscrapers/en/ororo.py
+++ b/lib/openscrapers/sources_openscrapers/en/ororo.py
@@ -25,7 +25,9 @@
 import base64
 import json
 import re
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cache
 from openscrapers.modules import client
@@ -48,8 +50,20 @@ class source:
 		self.user = control.setting('ororo.user')
 		self.password = control.setting('ororo.pass')
 		self.headers = {
-			'Authorization': 'Basic %s' % base64.b64encode('%s:%s' % (self.user, self.password)),
+			'Authorization': self._get_auth(),
 			'User-Agent': 'Placenta for Kodi'}
+
+	def _get_auth(self):
+		try:
+			# Python 2
+			user_info = '%s:%s' % (self.user, self.password)
+			auth = 'Basic ' + base64.b64encode(user_info)
+		except:
+			# Python 3
+			user_info = '%s:%s' % (self.user, self.password)
+			user_info = user_info.encode('utf-8')
+			auth = 'Basic ' + base64.b64encode(user_info).decode('utf-8')
+		return auth
 
 
 	def movie(self, imdb, title, localtitle, aliases, year):
@@ -83,7 +97,7 @@ class source:
 				return
 			if url == None:
 				return
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 
 			r = client.request(url, headers=self.headers)
 			r = json.loads(r)['episodes']
@@ -100,7 +114,7 @@ class source:
 
 	def ororo_moviecache(self, user):
 		try:
-			url = urlparse.urljoin(self.base_link, self.moviesearch_link)
+			url = urljoin(self.base_link, self.moviesearch_link)
 			r = client.request(url, headers=self.headers)
 			r = json.loads(r)['movies']
 			r = [(str(i['id']), str(i['imdb_id'])) for i in r]
@@ -112,7 +126,7 @@ class source:
 
 	def ororo_tvcache(self, user):
 		try:
-			url = urlparse.urljoin(self.base_link, self.tvsearch_link)
+			url = urljoin(self.base_link, self.tvsearch_link)
 			r = client.request(url, headers=self.headers)
 			r = json.loads(r)['shows']
 			r = [(str(i['id']), str(i['imdb_id'])) for i in r]
@@ -131,7 +145,7 @@ class source:
 			if (self.user == '' or self.password == ''):
 				raise Exception()
 
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			url = client.request(url, headers=self.headers)
 			url = json.loads(url)['url']
 

--- a/lib/openscrapers/sources_openscrapers/en/primewire.py
+++ b/lib/openscrapers/sources_openscrapers/en/primewire.py
@@ -25,8 +25,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -48,9 +51,8 @@ class source:
 
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
-			query = self.search_link % urllib.quote_plus(title)
-			query = urlparse.urljoin(self.base_link, query.lower())
-			print query
+			query = self.search_link % quote_plus(title)
+			query = urljoin(self.base_link, query.lower())
 			result = client.request(query, referer=self.base_link)
 			result = client.parseDOM(result, 'div', attrs={'class': 'index_item.+?'})
 			result = [(dom.parse_dom(i, 'a', req=['href', 'title'])[0]) for i in result if i]
@@ -61,7 +63,10 @@ class source:
 				          re.sub('(\.|\(|\[|\s)(\d{4}|S\d+E\d+|S\d+|3D)(\.|\)|\]|\s|)(.+|)', '',
 				                 i.attrs['title'], flags=re.I))][0]
 			url = client.replaceHTMLCodes(result)
-			url = url.encode('utf-8')
+			try:
+				url = url.encode('utf-8')
+			except:
+				pass
 			return url
 		except:
 			source_utils.scraper_error('PRIMEWIRE')
@@ -70,9 +75,9 @@ class source:
 
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
-			query = self.tvsearch_link % urllib.quote_plus(
+			query = self.tvsearch_link % quote_plus(
 				cleantitle.query(tvshowtitle))
-			query = urlparse.urljoin(self.base_link, query.lower())
+			query = urljoin(self.base_link, query.lower())
 			result = client.request(query, referer=self.base_link)
 			result = client.parseDOM(result, 'div', attrs={'class': 'index_item.+?'})
 			result = [(dom.parse_dom(i, 'a', req=['href', 'title'])[0]) for i in result if i]
@@ -83,7 +88,10 @@ class source:
 					re.sub('(\.|\(|\[|\s)(\d{4}|S\d+E\d+|S\d+|3D)(\.|\)|\]|\s|)(.+|)', '', i.attrs['title'], flags=re.I))][0]
 
 			url = client.replaceHTMLCodes(result)
-			url = url.encode('utf-8')
+			try:
+				url = url.encode('utf-8')
+			except:
+				pass
 			return url
 		except:
 			source_utils.scraper_error('PRIMEWIRE')
@@ -95,12 +103,15 @@ class source:
 			if url is None:
 				return
 
-			url = urlparse.urljoin(self.base_link, url) if url.startswith('/') else url
+			url = urljoin(self.base_link, url) if url.startswith('/') else url
 			url = url.split('online.html')[0]
 			url = '%s%s-online.html' % (url, 'season-%01d-episode-%01d' % (int(season), int(episode)))
 
 			url = client.replaceHTMLCodes(url)
-			url = url.encode('utf-8')
+			try:
+				url = url.encode('utf-8')
+			except:
+				pass
 			return url
 		except:
 			source_utils.scraper_error('PRIMEWIRE')
@@ -113,7 +124,7 @@ class source:
 			if url is None:
 				return sources
 
-			url = urlparse.urljoin(self.base_link, url) if not url.startswith('http') else url
+			url = urljoin(self.base_link, url) if not url.startswith('http') else url
 
 			result = client.request(url)
 			data = re.findall(r'\s*(eval.+?)\s*</script', result, re.DOTALL)[1]
@@ -131,9 +142,12 @@ class source:
 					data = [
 						(client.parseDOM(i, 'a', ret='href')[0],
 						 client.parseDOM(i, 'span', attrs={'class': 'version_host'})[0])][0]
-					url = urlparse.urljoin(self.base_link, data[0])
+					url = urljoin(self.base_link, data[0])
 					url = client.replaceHTMLCodes(url)
-					url = url.encode('utf-8')
+					try:
+						url = url.encode('utf-8')
+					except:
+						pass
 
 					host = data[1]
 					valid, host = source_utils.is_host_valid(host, hostDict)
@@ -187,7 +201,6 @@ class source:
 				except:
 					source_utils.scraper_error('PRIMEWIRE')
 					link = client.request(url, output='geturl', timeout=10)
-					print link
 					if link == url:
 						return
 					else:

--- a/lib/openscrapers/sources_openscrapers/en/showbox.py
+++ b/lib/openscrapers/sources_openscrapers/en/showbox.py
@@ -30,8 +30,11 @@ import base64
 import json
 import re
 import time
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import cleantitle
@@ -51,7 +54,7 @@ class source:
 		try:
 			aliases.append({'country': 'us', 'title': title})
 			url = {'imdb': imdb, 'title': title, 'year': year, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('SHOWBOX')
@@ -62,7 +65,7 @@ class source:
 		try:
 			aliases.append({'country': 'us', 'title': tvshowtitle})
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year, 'aliases': aliases}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('SHOWBOX')
@@ -73,10 +76,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('SHOWBOX')
@@ -120,7 +123,7 @@ class source:
 			sources = []
 			if url is None:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
 			imdb = data['imdb']
@@ -147,18 +150,18 @@ class source:
 				auth = re.findall('__utmx=(.+)', cookie)[0].split(';')[0]
 			except:
 				auth = 'false'
-			auth = 'Bearer %s' % urllib.unquote_plus(auth)
+			auth = 'Bearer %s' % unquote_plus(auth)
 			headers['Authorization'] = auth
 			headers['Referer'] = url
 			u = '/ajax/vsozrflxcw.php'
 			self.base_link = client.request(self.base_link, headers=headers, output='geturl')
-			u = urlparse.urljoin(self.base_link, u)
+			u = urljoin(self.base_link, u)
 			action = 'getEpisodeEmb' if '/episode/' in url else 'getMovieEmb'
-			elid = urllib.quote(base64.encodestring(str(int(time.time()))).strip())
+			elid = quote(base64.encodestring(str(int(time.time()))).strip())
 			token = re.findall("var\s+tok\s*=\s*'([^']+)", result)[0]
 			idEl = re.findall('elid\s*=\s*"([^"]+)', result)[0]
 			post = {'action': action, 'idEl': idEl, 'token': token, 'nopop': '', 'elid': elid}
-			post = urllib.urlencode(post)
+			post = urlencode(post)
 			cookie += ';%s=%s' % (idEl, elid)
 			headers['Cookie'] = cookie
 			r = client.request(u, post=post, headers=headers, cookie=cookie, XHR=True)

--- a/lib/openscrapers/sources_openscrapers/en/watch32.py
+++ b/lib/openscrapers/sources_openscrapers/en/watch32.py
@@ -25,8 +25,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -47,7 +50,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('WATCH32')
@@ -60,15 +63,15 @@ class source:
 			if url is None:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['title']
 			hdlr = data['year']
 
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', ' ', title)
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 			r = client.request(url)
 			if not r:
@@ -99,13 +102,13 @@ class source:
 			for item in items:
 				try:
 					r = client.request(item[0]) if item[0].startswith('http') else client.request(
-						urlparse.urljoin(self.base_link, item[0]))
+						urljoin(self.base_link, item[0]))
 
 					qual = client.parseDOM(r, 'h1')[0]
 					quality = source_utils.get_release_quality(item[1], qual)[0]
 
 					url = re.findall('''frame_url\s*=\s*["']([^']+)['"]\;''', r, re.DOTALL)[0]
-					url = url if url.startswith('http') else urlparse.urljoin('https://', url)
+					url = url if url.startswith('http') else urljoin('https://', url)
 
 					sources.append({'source': 'gvideo', 'quality': quality, 'info': '', 'language': 'en', 'url': url,
 									'direct': False, 'debridonly': False})

--- a/lib/openscrapers/sources_openscrapers/en/watchepisodes.py
+++ b/lib/openscrapers/sources_openscrapers/en/watchepisodes.py
@@ -25,8 +25,11 @@
 '''
 
 import json
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -45,7 +48,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('WATCHEPISODES')
@@ -57,10 +60,10 @@ class source:
 			if url is None:
 				return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('WATCHEPISODES')
@@ -73,13 +76,13 @@ class source:
 			if url is None:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle']
 			hdlr = 's%02de%02d' % (int(data['season']), int(data['episode']))
-			query = urllib.quote_plus(cleantitle.getsearch(title))
-			surl = urlparse.urljoin(self.base_link, self.search_link % query)
+			query = quote_plus(cleantitle.getsearch(title))
+			surl = urljoin(self.base_link, self.search_link % query)
 			# log_utils.log('surl = %s' % surl, log_utils.LOGDEBUG)
 
 			r = client.request(surl, XHR=True)
@@ -92,7 +95,7 @@ class source:
 				if cleantitle.get(title) != cleantitle.get(tit):
 					continue
 				slink = i['seo']
-				slink = urlparse.urljoin(self.base_link, slink)
+				slink = urljoin(self.base_link, slink)
 				r = client.request(slink)
 
 				if not data['imdb'] in r:

--- a/lib/openscrapers/sources_openscrapers/en/watchepisodeseries1.py
+++ b/lib/openscrapers/sources_openscrapers/en/watchepisodeseries1.py
@@ -26,8 +26,11 @@
 '''
 
 import json
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -46,7 +49,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('WATCHEPISODESERIES1')
@@ -57,10 +60,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('WATCHEPISODESERIES1')
@@ -73,13 +76,13 @@ class source:
 			if url is None:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle']
 			hdlr = 's%02de%02d' % (int(data['season']), int(data['episode']))
-			query = urllib.quote_plus(cleantitle.getsearch(title))
-			surl = urlparse.urljoin(self.base_link, self.search_link % query)
+			query = quote_plus(cleantitle.getsearch(title))
+			surl = urljoin(self.base_link, self.search_link % query)
 			r = client.request(surl, XHR=True, timeout='10')
 			if not r:
 				return sources
@@ -91,7 +94,7 @@ class source:
 				if cleantitle.get(title) != cleantitle.get(tit):
 					continue
 				slink = '/' + i['seo_name']
-				slink = urlparse.urljoin(self.base_link, slink)
+				slink = urljoin(self.base_link, slink)
 				r = client.request(slink, timeout='10')
 				data = client.parseDOM(r, 'div', attrs={'class': 'el-item\s*'})
 				ep = [i for i in client.parseDOM(data, 'a', ret='href') if hdlr in i.lower()][0]

--- a/lib/openscrapers/sources_openscrapers/en/watchseries.py
+++ b/lib/openscrapers/sources_openscrapers/en/watchseries.py
@@ -25,8 +25,9 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -54,7 +55,7 @@ class source:
 
 	def episode(self, url, imdb, tvdb, title, premiered, season, episode):
 		try:
-			url = urlparse.urljoin(self.base_link, self.search_link % (url, season, episode))
+			url = urljoin(self.base_link, self.search_link % (url, season, episode))
 			return url
 		except:
 			source_utils.scraper_error('WATCHSERIES')
@@ -78,7 +79,10 @@ class source:
 				if not valid:
 					continue
 				try:
-					url.decode('utf-8')
+					try:
+						url.decode('utf-8')
+					except:
+						pass
 					sources.append({'source': hoster, 'quality': 'SD', 'info': '', 'language': 'en', 'url': url, 'direct': False, 'debridonly': False})
 				except:
 					source_utils.scraper_error('WATCHSERIES')

--- a/lib/openscrapers/sources_openscrapers/en/xwatchseries.py
+++ b/lib/openscrapers/sources_openscrapers/en/xwatchseries.py
@@ -25,8 +25,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urlparse
+except ImportError: from urllib.parse import parse_qs, urlparse
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -50,7 +53,7 @@ class source:
 			q = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', tvshowtitle)
 
 			# r = self.scraper.get(self.search_link % q, headers={'referer': self.base_link}).content
-			r = self.scraper.get(self.search_link % urllib.quote_plus(q), headers={'referer': self.base_link}).content
+			r = self.scraper.get(self.search_link % quote_plus(q), headers={'referer': self.base_link}).content
 			# log_utils.log('r = %s' % r, __name__, log_utils.LOGDEBUG)
 
 			# r = client.parseDOM(r, 'div', attrs={'valign': '.+?'})
@@ -111,15 +114,21 @@ class source:
 				try:
 					url = i
 					url = proxy.parse(url)
-					url = urlparse.parse_qs(urlparse.urlparse(url).query)['r'][0]
+					url = parse_qs(urlparse(url).query)['r'][0]
 					url = url.decode('base64')
 					url = client.replaceHTMLCodes(url)
-					url = url.encode('utf-8')
+					try:
+						url = url.encode('utf-8')
+					except:
+						pass
 
-					host = re.findall('([\w]+[.][\w]+)$', urlparse.urlparse(url.strip().lower()).netloc)[0]
+					host = re.findall('([\w]+[.][\w]+)$', urlparse(url.strip().lower()).netloc)[0]
 					if host not in hostDict:
 						continue;
-					host = host.encode('utf-8')
+					try:
+						host = host.encode('utf-8')
+					except:
+						pass
 					sources.append({'source': host, 'quality': 'SD', 'info': '', 'language': 'en', 'url': url, 'direct': False,
 					                'debridonly': False})
 				except:

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/300mbfilms.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/300mbfilms.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('300MBFILMS')
@@ -58,7 +61,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('300MBFILMS')
@@ -69,10 +72,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('300MBFILMS')
@@ -91,7 +94,7 @@ class source:
 
 			hostDict = hostprDict + hostDict
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -102,8 +105,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 			r = client.request(url)
 			posts = client.parseDOM(r, 'h2')
@@ -157,14 +160,20 @@ class source:
 				if any(x in item[0] for x in ['.rar', '.zip', '.iso']):
 					continue
 				url = client.replaceHTMLCodes(item[0])
-				url = url.encode('utf-8')
+				try:
+					url = url.encode('utf-8')
+				except:
+					pass
 
 				valid, host = source_utils.is_host_valid(url, hostDict)
 				if not valid:
 					continue
 
 				host = client.replaceHTMLCodes(host)
-				host = host.encode('utf-8')
+				try:
+					host = host.encode('utf-8')
+				except:
+					pass
 
 				sources.append({'source': host, 'quality': item[1], 'language': 'en', 'url': url, 'info': item[2], 'direct': False, 'debridonly': True, 'size': dsize})
 			return sources

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/ddlspot.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/ddlspot.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -47,7 +50,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -56,7 +59,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -66,10 +69,10 @@ class source:
 		try:
 			if url is None: return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -87,7 +90,7 @@ class source:
 
 			hostDict = hostprDict + hostDict
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,8 +101,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url).replace('-', '+')
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url).replace('-', '+')
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url)
@@ -157,7 +160,10 @@ class source:
 									continue
 
 								host = client.replaceHTMLCodes(host)
-								host = host.encode('utf-8')
+								try:
+									host = host.encode('utf-8')
+								except:
+									pass
 
 								sources.append({'source': host, 'quality': quality, 'language': 'en', 'url': url,
 															'info': info, 'direct': False, 'debridonly': True, 'size': dsize})

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/ganool.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/ganool.py
@@ -11,8 +11,11 @@
 
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs
+except ImportError: from urllib.parse import parse_qs
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cfscrape, client
 from openscrapers.modules import cleantitle
@@ -37,7 +40,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -53,7 +56,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			q = '%s' % cleantitle.get_gan_url(data['title'])

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/maxrls.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/maxrls.py
@@ -27,8 +27,11 @@
 
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -49,7 +52,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -58,7 +61,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -68,10 +71,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -90,7 +93,7 @@ class source:
 
 			hostDict = hostprDict + hostDict
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -101,8 +104,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url).replace('%3A+', '+')
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url).replace('%3A+', '+')
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = self.scraper.get(url).content

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/mkvhub.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/mkvhub.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -49,7 +52,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -58,7 +61,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -68,10 +71,10 @@ class source:
 		try:
 			if url is None: return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if url is None:
 				return self._sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -96,8 +99,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = self.scraper.get(url).content
@@ -206,7 +209,7 @@ class source:
 				elif 'torrent' in url:
 					data = client.parseDOM(r, 'a', ret='href')
 					url = [i for i in data if 'magnet:' in i][0]
-					url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+					url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 					url = url.split('&tr')[0]
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 					name = url.split('&dn=')[1]

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/myvideolink.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/myvideolink.py
@@ -10,8 +10,11 @@
 #  ..#######.##.......#######.##....#..######..######.##.....#.##.....#.##.......#######.##.....#..######.
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -32,7 +35,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -41,7 +44,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -51,21 +54,21 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
 
 
 	def sources(self, url, hostDict, hostprDict):
+		sources = []
 		try:
 			test = client.request(self.base_link)
 			new_search = client.parseDOM(test, 'form', ret='action')[0] # to try to combat their constant search link changes
 
-			sources = []
 
 			if url is None:
 				return sources
@@ -73,7 +76,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -84,9 +87,9 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			# url = urlparse.urljoin(self.base_link, self.search_link)
-			url = urlparse.urljoin(new_search, self.search_link)
-			url = url % urllib.quote_plus(query)
+			# url = urljoin(self.base_link, self.search_link)
+			url = urljoin(new_search, self.search_link)
+			url = url % quote_plus(query)
 			# log_utils.log('url = %s' % url, __name__, log_utils.LOGDEBUG)
 			r = client.request(url, timeout='5')
 			if not r:
@@ -139,7 +142,10 @@ class source:
 				try:
 					url = item[1]
 					url = client.replaceHTMLCodes(url)
-					url = url.encode('utf-8')
+					try:
+						url = url.encode('utf-8')
+					except:
+						pass
 					if url.endswith(('.rar', '.zip', '.iso', '.part', '.png', '.jpg', '.bmp', '.gif')):
 						continue
 
@@ -148,7 +154,10 @@ class source:
 						continue
 
 					host = client.replaceHTMLCodes(host)
-					host = host.encode('utf-8')
+					try:
+						host = host.encode('utf-8')
+					except:
+						pass
 
 					name = item[0]
 					name = client.replaceHTMLCodes(name).replace(' ', '.')

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/onceddl.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/onceddl.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -47,7 +50,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -56,7 +59,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -66,10 +69,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -87,7 +90,7 @@ class source:
 
 			hostDict = hostprDict + hostDict
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,8 +101,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url).replace('-', '+')
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url).replace('-', '+')
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url)

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/onlineseries.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/onlineseries.py
@@ -27,8 +27,11 @@
 
 import re
 import time
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -51,7 +54,7 @@ class source:
 		self.aliases = [cleantitle.get(i['title']) for i in aliases]
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -61,7 +64,7 @@ class source:
 		self.aliases = [cleantitle.get(i['title']) for i in aliases]
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -71,10 +74,10 @@ class source:
 		try:
 			if url is None: return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -92,7 +95,7 @@ class source:
 
 			self.hostDict = hostDict + hostprDict
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -104,8 +107,8 @@ class source:
 			query = '%s %s' % (self.title, self.hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url)
@@ -184,7 +187,10 @@ class source:
 					continue
 
 				host = client.replaceHTMLCodes(host)
-				host = host.encode('utf-8')
+				try:
+					host = host.encode('utf-8')
+				except:
+					pass
 
 				quality, info2 = source_utils.get_release_quality(name, url)
 

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/rlsbb.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/rlsbb.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin, urlparse
+except ImportError: from urllib.parse import parse_qs, urljoin, urlparse
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -50,7 +53,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -59,7 +62,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -70,10 +73,10 @@ class source:
 			if url is None:
 				return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -91,7 +94,7 @@ class source:
 
 			hostDict = hostprDict + hostDict
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -105,8 +108,8 @@ class source:
 			query = re.sub('\s', '-', query)
 			# log_utils.log('query = %s' % query, log_utils.LOGDEBUG)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			url = "http://rlsbb.ru/" + query
 
 			if 'tvshowtitle' not in data:
@@ -138,7 +141,10 @@ class source:
 
 					for i in u:
 						try:
-							name = i.encode('ascii', errors='ignore').decode('ascii', errors='ignore').replace('&nbsp;', ' ')
+							try:
+								name = i.encode('ascii', errors='ignore').decode('ascii', errors='ignore').replace('&nbsp;', ' ')
+							except:
+								name = i.replace('&nbsp;', ' ')
 							tit = name.rsplit('/', 1)[1]
 							t = tit.split(hdlr)[0].replace(data['year'], '').replace('(', '').replace(')', '').replace('&', 'and')
 							if cleantitle.get(t) != cleantitle.get(title):
@@ -161,7 +167,10 @@ class source:
 
 					url = str(item)
 					url = client.replaceHTMLCodes(url)
-					url = url.encode('utf-8')
+					try:
+						url = url.encode('utf-8')
+					except:
+						pass
 
 					if url in seen_urls:
 						continue
@@ -171,7 +180,7 @@ class source:
 					host2 = host.strip('"')
 					if url in str(sources):
 						continue
-					host = re.findall('([\w]+[.][\w]+)$', urlparse.urlparse(host2.strip().lower()).netloc)[0]
+					host = re.findall('([\w]+[.][\w]+)$', urlparse(host2.strip().lower()).netloc)[0]
 
 					if not host in hostDict:
 						continue
@@ -193,7 +202,10 @@ class source:
 					info = ' | '.join(info)
 
 					host = client.replaceHTMLCodes(host)
-					host = host.encode('utf-8')
+					try:
+						host = host.encode('utf-8')
+					except:
+						pass
 
 					sources.append({'source': host, 'quality': quality, 'language': 'en', 'url': host2, 'info': info, 'direct': False, 'debridonly': True, 'size': dsize})
 

--- a/lib/openscrapers/sources_openscrapers/en_DebridOnly/scenerls.py
+++ b/lib/openscrapers/sources_openscrapers/en_DebridOnly/scenerls.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin, urlparse
+except ImportError: from urllib.parse import parse_qs, urljoin, urlparse
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import cleantitle
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -88,7 +91,7 @@ class source:
 
 			hostDict = hostprDict + hostDict
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -100,8 +103,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			try:
-				url = self.search_link % urllib.quote_plus(query)
-				url = urlparse.urljoin(self.base_link, url)
+				url = self.search_link % quote_plus(query)
+				url = urljoin(self.base_link, url)
 				# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 				r = scraper.get(url).content
@@ -161,16 +164,22 @@ class source:
 						continue
 
 					url = client.replaceHTMLCodes(url)
-					url = url.encode('utf-8')
+					try:
+						url = url.encode('utf-8')
+					except:
+						pass
 					if url in str(sources):
 						continue
 
-					host = re.findall('([\w]+[.][\w]+)$', urlparse.urlparse(url.strip().lower()).netloc)[0]
+					host = re.findall('([\w]+[.][\w]+)$', urlparse(url.strip().lower()).netloc)[0]
 					if not host in hostDict:
 						continue
 
 					host = client.replaceHTMLCodes(host)
-					host = host.encode('utf-8')
+					try:
+						host = host.encode('utf-8')
+					except:
+						pass
 
 					sources.append({'source': host, 'quality': quality, 'language': 'en', 'url': url, 'info': info,
 									'direct': False, 'debridonly': True, 'size': dsize})

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/1337x.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/1337x.py
@@ -26,8 +26,10 @@
 '''
 
 import re
-import urllib
-import urlparse
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -49,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -58,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -68,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -88,7 +90,7 @@ class source:
 			if debrid.status() is False:
 				return self._sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -102,9 +104,9 @@ class source:
 
 			urls = []
 			if 'tvshowtitle' in data:
-				urls.append(self.tvsearch % (urllib.quote(query)))
+				urls.append(self.tvsearch % (quote(query)))
 			else:
-				urls.append(self.moviesearch % (urllib.quote(query)))
+				urls.append(self.moviesearch % (quote(query)))
 
 			url2 = ''.join(urls).replace('/1/', '/2/')
 			urls.append(url2)
@@ -139,7 +141,7 @@ class source:
 
 			for post in posts:
 				data = client.parseDOM(post, 'a', ret='href')[1]
-				link = urlparse.urljoin(self.base_link, data)
+				link = urljoin(self.base_link, data)
 
 				try:
 					seeders = int(client.parseDOM(post, 'td', attrs={'class': 'coll-2 seeds'})[0].replace(',', ''))
@@ -150,7 +152,7 @@ class source:
 					pass
 
 				name = client.parseDOM(post, 'a')[1]
-				name = urllib.unquote_plus(name)
+				name = unquote_plus(name)
 				name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 				if source_utils.remove_lang(name):
 					continue
@@ -189,7 +191,7 @@ class source:
 			data = client.parseDOM(data, 'a', ret='href')
 
 			url = [i for i in data if 'magnet:' in i][0]
-			url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+			url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 			url = url.split('&tr')[0]
 			hash = re.compile('btih:(.*?)&').findall(url)[0]
 

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/7torrents.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/7torrents.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,8 +101,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			urls.append(url)
 			urls.append(url + '&p=2')
 			# log_utils.log('urls = %s' % urls, log_utils.LOGDEBUG)
@@ -134,9 +137,12 @@ class source:
 					pass
 
 				url = re.findall('href="(magnet:.+?)"', row, re.DOTALL)[0]
-				url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+				url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 				url = url.split('&tr')[0]
-				url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+				try:
+					url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+				except:
+					pass
 				hash = re.compile('btih:(.*?)&').findall(url)[0]
 
 				name = url.split('&dn=')[1]

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/bitlord.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/bitlord.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -49,7 +52,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -58,7 +61,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -68,10 +71,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -86,7 +89,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -97,8 +100,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url)
@@ -108,8 +111,11 @@ class source:
 
 			for link in links:
 				try:
-					url = urllib.unquote_plus(link[0]).replace('&amp;', '&').replace(' ', '.')
-					url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+					url = unquote_plus(link[0]).replace('&amp;', '&').replace(' ', '.')
+					try:
+						url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+					except:
+						pass
 					url = re.sub(r'(&tr=.+)&dn=', '&dn=', url) # some links on bitlord &tr= before &dn=
 					url = url.split('&tr=')[0]
 					url = url.split('&xl=')[0]

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/btdb.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/btdb.py
@@ -26,15 +26,17 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote, unquote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import client
 from openscrapers.modules import debrid
 from openscrapers.modules import source_utils
 from openscrapers.modules import workers
-
 
 class source:
 	def __init__(self):
@@ -48,7 +50,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +59,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +69,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +87,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,9 +100,9 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			# url = self.search_link % urllib.quote_plus(query)
-			url = self.search_link % urllib.quote(query + ' -soundtrack')
-			url = urlparse.urljoin(self.base_link, url)
+			# url = self.search_link % quote_plus(query)
+			url = self.search_link % quote(query + ' -soundtrack')
+			url = urljoin(self.base_link, url)
 			urls.append(url)
 			urls.append(url + '&page=2')
 			# log_utils.log('urls = %s' % urls, __name__, log_utils.LOGDEBUG)
@@ -136,7 +138,7 @@ class source:
 
 				link = re.findall('<a href="(magnet:.+?)"', post, re.DOTALL)
 				for url in link:
-					url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+					url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 					url = url.split('&tr')[0]
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/btscene.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/btscene.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,8 +101,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			urls.append(url)
 			urls.append(url + '&p=2')
 			# log_utils.log('urls = %s' % urls, log_utils.LOGDEBUG)
@@ -135,7 +138,7 @@ class source:
 						seeders = 0
 						pass
 
-					url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+					url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 					url = url.split('&tr')[0]
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/ettv.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/ettv.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -97,8 +100,8 @@ class source:
 			query = '%s %s' % (self.title, self.hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			try:
@@ -129,7 +132,10 @@ class source:
 				return
 
 			url = 'magnet:%s' % (re.findall('a href="magnet:(.+?)"', result, re.DOTALL)[0])
-			url = urllib.unquote_plus(url).decode('utf8').replace('&amp;', '&').replace(' ', '.')
+			try:
+				url = unquote_plus(url).decode('utf8').replace('&amp;', '&').replace(' ', '.')
+			except:
+				pass
 			url = url.split('&xl=')[0]
 			if url in str(self.sources):
 				return

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/extratorrent.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/extratorrent.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import client
@@ -49,7 +52,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('EXTRATORRENT')
@@ -59,7 +62,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('EXTRATORRENT')
@@ -70,10 +73,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			source_utils.scraper_error('EXTRATORRENT')
@@ -91,7 +94,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -104,8 +107,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			urls.append(url)
 			# urls.append('%s%s' % (url, '&page=2')) # next page seems broken right now
 			# urls.append('%s%s' % (url, '&page=3'))
@@ -135,9 +138,12 @@ class source:
 	def get_sources(self, link):
 		try:
 			url = 'magnet:%s' % (re.findall('a href="magnet:(.+?)"', link, re.DOTALL)[0])
-			url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+			url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 			url = url.split('&tr')[0]
-			url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+			try:
+				url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+			except:
+				pass
 
 			hash = re.compile('btih:(.*?)&').findall(url)[0]
 

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/eztv.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/eztv.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -47,7 +50,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,10 +60,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -75,7 +78,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'].replace('&', 'and').replace('Special Victims Unit', 'SVU')
@@ -85,8 +88,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % (urllib.quote_plus(query).replace('+', '-'))
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % (quote_plus(query).replace('+', '-'))
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 			html = client.request(url)
 			try:
@@ -111,11 +114,14 @@ class source:
 						continue
 
 					url = 'magnet:%s' % (str(client.replaceHTMLCodes(derka[0]).split('&tr')[0]))
-					url = urllib.unquote(url).decode('utf8')
+					try:
+						url = unquote(url).decode('utf8')
+					except:
+						pass
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 
 					magnet_title = derka[1]
-					name = urllib.unquote_plus(magnet_title)
+					name = unquote_plus(magnet_title)
 					name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 					if source_utils.remove_lang(name):
 						continue

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/glodls.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/glodls.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -86,7 +89,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -99,10 +102,10 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			if 'tvshowtitle' in data:
-				url = self.tvsearch.format(urllib.quote_plus(query))
+				url = self.tvsearch.format(quote_plus(query))
 			else:
-				url = self.moviesearch.format(urllib.quote_plus(query))
-			url = urlparse.urljoin(self.base_link, url)
+				url = self.moviesearch.format(quote_plus(query))
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			items = self._get_items(url)
@@ -111,7 +114,7 @@ class source:
 				try:
 					name = item[0]
 
-					url = urllib.unquote_plus(item[1]).replace('&amp;', '&').replace(' ', '.')
+					url = unquote_plus(item[1]).replace('&amp;', '&').replace(' ', '.')
 					url = url.split('&tr')[0]
 
 					hash = re.compile('btih:(.*?)&').findall(url)[0].lower()
@@ -146,7 +149,7 @@ class source:
 				url = [i for i in ref if 'magnet:' in i][0]
 
 				name = client.parseDOM(post, 'a', ret='title')[0]
-				name = urllib.unquote_plus(name)
+				name = unquote_plus(name)
 				name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 				if source_utils.remove_lang(name):
 					continue

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/idope.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/idope.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,8 +101,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			urls.append(url)
 			urls.append(url + '?p=2')
 			# log_utils.log('urls = %s' % urls, log_utils.LOGDEBUG)
@@ -126,7 +129,7 @@ class source:
 				for post in row:
 					hash = re.findall('<div id="hideinfohash.+?" class="hideinfohash">(.+?)<', post, re.DOTALL)[0]
 					name = re.findall('<div id="hidename.+?" class="hideinfohash">(.+?)<', post, re.DOTALL)[0]
-					name = urllib.unquote_plus(name)
+					name = unquote_plus(name)
 					name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 
 					if name.startswith('www'):

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/isohunt2.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/isohunt2.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,8 +101,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			urls.append(url)
 			# urls.append(url.replace('page=0', 'page=40')) # server response time WAY to slow to parse 2 pages deep, site sucks.
 			# log_utils.log('urls = %s' % urls, log_utils.LOGDEBUG)
@@ -127,7 +130,7 @@ class source:
 				links = re.compile('<a href="(/torrent_details/.+?)"><span>(.+?)</span>.*?<td class="size-row">(.+?)</td><td class="sn">([0-9]+)</td>').findall(post)
 
 				for items in links:
-					link = urlparse.urljoin(self.base_link, items[0])
+					link = urljoin(self.base_link, items[0])
 					name = items[1]
 					name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 					if source_utils.remove_lang(name):
@@ -147,7 +150,7 @@ class source:
 
 					link = client.request(link, timeout='5')
 					magnet = re.compile('(magnet.+?)"').findall(link)[0]
-					url = urllib.unquote_plus(magnet).replace('&amp;', '&').replace(' ', '.')
+					url = unquote_plus(magnet).replace('&amp;', '&').replace(' ', '.')
 					url = url.split('&tr')[0]
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/limetorrents.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/limetorrents.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote, unquote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import client
@@ -50,7 +53,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -59,7 +62,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -69,10 +72,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -90,7 +93,7 @@ class source:
 			if debrid.status() is False:
 				return self._sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -104,9 +107,9 @@ class source:
 
 			urls = []
 			if 'tvshowtitle' in data:
-				url = self.tvsearch.format(urllib.quote(query))
+				url = self.tvsearch.format(quote(query))
 			else:
-				url = self.moviesearch.format(urllib.quote(query))
+				url = self.moviesearch.format(quote(query))
 			urls.append(url)
 
 			url2 = url.replace('/1/', '/2/')
@@ -150,10 +153,10 @@ class source:
 					pass
 
 				data = re.sub('\s', '', data).strip()
-				link = urlparse.urljoin(self.base_link, data)
+				link = urljoin(self.base_link, data)
 
 				name = client.parseDOM(post, 'a')[1]
-				name = urllib.unquote_plus(name)
+				name = unquote_plus(name)
 				name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 				if source_utils.remove_lang(name):
 					continue
@@ -200,7 +203,7 @@ class source:
 
 			try:
 				url = re.search('''href=["'](magnet:\?[^"']+)''', data).groups()[0]
-				url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+				url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 				url = url.split('&tr')[0]
 			except:
 				return

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/magnet4you.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/magnet4you.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -49,7 +52,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -58,7 +61,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -68,10 +71,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -86,7 +89,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,8 +101,8 @@ class source:
 			query = '%s %s' % (self.title, self.hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url)
@@ -124,9 +127,12 @@ class source:
 				return
 
 			url = re.findall('href="(magnet:.+?)"', row, re.DOTALL)[0]
-			url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+			url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 			url = url.split('&tr')[0]
-			url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+			try:
+				url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+			except:
+				pass
 			hash = re.compile('btih:(.*?)&').findall(url)[0]
 
 			name = url.split('&dn=')[1]

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/magnetdl.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/magnetdl.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, unquote_plus
+except ImportError: from urllib.parse import urlencode, unquote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -84,7 +87,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -95,7 +98,7 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = urlparse.urljoin(self.base_link, self.search_link.format(query[0].lower(), cleantitle.geturl(query)))
+			url = urljoin(self.base_link, self.search_link.format(query[0].lower(), cleantitle.geturl(query)))
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url)
@@ -125,7 +128,7 @@ class source:
 
 				links = client.parseDOM(post, 'a', ret='href')
 				magnet = [i.replace('&amp;', '&') for i in links if 'magnet:' in i][0]
-				url = urllib.unquote_plus(magnet).split('&tr')[0].replace(' ', '.')
+				url = unquote_plus(magnet).split('&tr')[0].replace(' ', '.')
 				if url in str(sources):
 					continue
 
@@ -140,7 +143,7 @@ class source:
 					pass
 
 				name = client.parseDOM(post, 'a', ret='title')[1]
-				name = urllib.unquote_plus(name)
+				name = unquote_plus(name)
 				name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 				if source_utils.remove_lang(name):
 					continue

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/moviemagnet.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/moviemagnet.py
@@ -26,9 +26,12 @@
 '''
 
 import re
-import urllib
-import urlparse
 import json
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -64,15 +67,15 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['title']
 			year = data['year']
 
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\||!)', '', title)
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 			try:
 				r = scraper.get(url).content
@@ -99,7 +102,7 @@ class source:
 
 				for link in links:
 					name = link[0]
-					name = urllib.unquote_plus(name)
+					name = unquote_plus(name)
 					name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 					if source_utils.remove_lang(name):
 						continue
@@ -108,7 +111,10 @@ class source:
 						continue
 
 					url = link[1]
-					url = urllib.unquote_plus(url).decode('utf8').replace('&amp;', '&').replace(' ', '.')
+					try:
+						url = unquote_plus(url).decode('utf8').replace('&amp;', '&').replace(' ', '.')
+					except:
+						url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 					url = url.split('&tr')[0]
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/nyaa.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/nyaa.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -101,11 +104,11 @@ class source:
 			query2 = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query2)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			urls.append(url)
-			url2 = self.search_link % urllib.quote_plus(query2)
-			url2 = urlparse.urljoin(self.base_link, url2)
+			url2 = self.search_link % quote_plus(query2)
+			url2 = urljoin(self.base_link, url2)
 			urls.append(url2)
 			# log_utils.log('urls = %s' % urls, log_utils.LOGDEBUG)
 
@@ -124,9 +127,12 @@ class source:
 						links = zip(re.findall('href="(magnet:.+?)"', row, re.DOTALL), re.findall('((?:\d+\,\d+\.\d+|\d+\.\d+|\d+\,\d+|\d+)\s*(?:GB|GiB|Gb|MB|MiB|Mb))', row, re.DOTALL), [re.findall('<td class="text-center">([0-9]+)</td>', row, re.DOTALL)])
 
 						for link in links:
-							url = urllib.unquote_plus(link[0]).replace('&amp;', '&').replace(' ', '.')
+							url = unquote_plus(link[0]).replace('&amp;', '&').replace(' ', '.')
 							url = url.split('&tr')[0]
-							url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+							try:
+								url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+							except:
+								pass
 							hash = re.compile('btih:(.*?)&').findall(url)[0]
 
 							name = url.split('&dn=')[1]

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/piratebay.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/piratebay.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote, unquote_plus
 
 from openscrapers.modules import cache
 from openscrapers.modules import client
@@ -56,7 +59,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -65,7 +68,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -75,10 +78,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -93,7 +96,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -104,8 +107,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			html = client.request(url)
@@ -136,12 +139,12 @@ class source:
 					continue
 				try:
 					url = 'magnet:%s' % (re.findall('a href="magnet:(.+?)"', entry, re.DOTALL)[0])
-					url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+					url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 					url = url.split('&tr')[0]
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 
 					name = re.findall('class="detLink" title=".+?">(.+?)</a>', entry, re.DOTALL)[0]
-					name = urllib.unquote_plus(name)
+					name = unquote_plus(name)
 					name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 					if source_utils.remove_lang(name):
 						continue

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/solidtorrents.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/solidtorrents.py
@@ -26,9 +26,12 @@
 '''
 
 import re
-import urllib
-import urlparse
 import json
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -49,7 +52,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -58,7 +61,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -68,10 +71,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -86,7 +89,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -99,8 +102,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			urls.append(url)
 			urls.append(url + '&skip=20')
 			urls.append(url + '&skip=40')
@@ -129,7 +132,7 @@ class source:
 
 			for item in results:
 				try:
-					url = urllib.unquote_plus(item['magnet']).replace(' ', '.')
+					url = unquote_plus(item['magnet']).replace(' ', '.')
 					url = re.sub(r'(&tr=.+)&dn=', '&dn=', url) # some links on solidtorrents &tr= before &dn=
 					hash = item['infohash'].lower()
 

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/topnow.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/topnow.py
@@ -26,9 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
 
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 from openscrapers.modules import client
 from openscrapers.modules import debrid
 from openscrapers.modules import source_utils
@@ -47,7 +49,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -56,7 +58,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -66,10 +68,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +87,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -99,9 +101,9 @@ class source:
 			if 'tvshowtitle' in data:
 				url = self.show_link % query.replace(' ', '-')
 			else:
-				url = self.search_link % urllib.quote_plus(query)
+				url = self.search_link % quote_plus(query)
 
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, __name__, log_utils.LOGDEBUG)
 
 			r = client.request(url)
@@ -113,7 +115,10 @@ class source:
 			r = client.parseDOM(r, 'div', attrs={'class': 'card'})
 			for i in r:
 				url = re.compile('href="(magnet.+?)\s*?"').findall(i)[0]
-				url = urllib.unquote_plus(url).decode('utf8').replace('&amp;', '&').replace(' ', '.')
+				try:
+					url = unquote_plus(url).decode('utf8').replace('&amp;', '&').replace(' ', '.')
+				except:
+					url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
 				url = url.split('&tr=')[0].replace(' ', '.')
 				hash = re.compile('btih:(.*?)&').findall(url)[0]
 

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/torlock.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/torlock.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -97,8 +100,8 @@ class source:
 			query = '%s %s' % (self.title, self.hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			try:
@@ -131,7 +134,10 @@ class source:
 				return
 
 			url = 'magnet:%s' % (re.findall('a href="magnet:(.+?)"', result, re.DOTALL)[0])
-			url = urllib.unquote_plus(url).decode('utf8').replace('&amp;', '&')
+			try:
+				url = unquote_plus(url).decode('utf8').replace('&amp;', '&')
+			except:
+				url = unquote_plus(url).replace('&amp;', '&')
 			url = url.split('&tr=')[0].replace(' ', '.')
 			if url in str(self.sources):
 				return

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/torrentapi.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/torrentapi.py
@@ -28,8 +28,11 @@
 import json
 import re
 import time
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs
+except ImportError: from urllib.parse import parse_qs
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -50,7 +53,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -59,7 +62,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -69,10 +72,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -87,7 +90,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -102,7 +105,7 @@ class source:
 			token = json.loads(token)["token"]
 
 			if 'tvshowtitle' in data:
-				search_link = self.tvsearch.format(token, urllib.quote_plus(query), 'limit=100&format=json_extended')
+				search_link = self.tvsearch.format(token, quote_plus(query), 'limit=100&format=json_extended')
 			else:
 				search_link = self.msearch.format(token, data['imdb'], 'limit=100&format=json_extended')
 			# log_utils.log('search_link = %s' % search_link, log_utils.LOGDEBUG)
@@ -120,7 +123,7 @@ class source:
 				hash = re.compile('btih:(.*?)&').findall(url)[0]
 
 				name = file["title"]
-				name = urllib.unquote_plus(name)
+				name = unquote_plus(name)
 				name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 				if source_utils.remove_lang(name):
 					continue

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/torrentdownload.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/torrentdownload.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,8 +101,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			urls.append(url)
 			urls.append(url + '&p=2')
 			# log_utils.log('urls = %s' % urls, log_utils.LOGDEBUG)

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/torrentdownloads.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/torrentdownloads.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs
+except ImportError: from urllib.parse import parse_qs
+try: from urllib import urlencode, quote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self._sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -98,9 +101,9 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			if 'tvshowtitle' in data:
-				url = self.search.format('8', urllib.quote(query))
+				url = self.search.format('8', quote(query))
 			else:
-				url = self.search.format('4', urllib.quote(query))
+				url = self.search.format('4', quote(query))
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			headers = {'User-Agent': client.agent()}
@@ -129,7 +132,7 @@ class source:
 
 			hash = re.search(r'<info_hash>([a-zA-Z0-9]+)</info_hash>', r).groups()[0]
 			name = re.search(r'<title>(.+?)</title>', r).groups()[0]
-			name = urllib.unquote_plus(name)
+			name = unquote_plus(name)
 			name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 			if source_utils.remove_lang(name):
 				return

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/torrentgalaxy.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/torrentgalaxy.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import cfscrape
 from openscrapers.modules import client
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -86,7 +89,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -97,8 +100,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = scraper.get(url).content
@@ -110,7 +113,7 @@ class source:
 							re.findall(r"<span title='Seeders/Leechers'>\[<font color='green'><b>(.*?)<", post, re.DOTALL))
 
 				for link in links:
-					url = urllib.unquote_plus(link[0]).split('&tr')[0].replace(' ', '.')
+					url = unquote_plus(link[0]).split('&tr')[0].replace(' ', '.')
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 
 					name = url.split('&dn=')[1]

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/torrentquest.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/torrentquest.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, unquote_plus
+except ImportError: from urllib.parse import urlencode, unquote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -86,7 +89,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -97,7 +100,7 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = urlparse.urljoin(self.base_link, self.search_link.format(query[0].lower(), cleantitle.geturl(query)))
+			url = urljoin(self.base_link, self.search_link.format(query[0].lower(), cleantitle.geturl(query)))
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url)
@@ -113,13 +116,13 @@ class source:
 				post = post.replace('&nbsp;', ' ')
 				links = client.parseDOM(post, 'a', ret='href')
 				magnet = [i.replace('&amp;', '&') for i in links if 'magnet:' in i][0]
-				url = urllib.unquote_plus(magnet).split('&tr')[0].replace(' ', '.')
+				url = unquote_plus(magnet).split('&tr')[0].replace(' ', '.')
 				if url in str(sources):
 					continue
 				hash = re.compile('btih:(.*?)&').findall(url)[0].lower()
 
 				name = client.parseDOM(post, 'a', ret='title')[1]
-				name = urllib.unquote_plus(name)
+				name = unquote_plus(name)
 				name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 				if source_utils.remove_lang(name):
 					continue

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/yourbittorrent.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/yourbittorrent.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'].lower() if 'tvshowtitle' in data else data['title'].lower()
@@ -97,8 +100,8 @@ class source:
 			query = '%s %s' % (self.title, self.hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url).replace('+', '-')
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url).replace('+', '-')
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			r = client.request(url, timeout='5')
@@ -130,7 +133,7 @@ class source:
 			hash = re.findall('<kbd>(.+?)<', result, re.DOTALL)[0]
 			url = '%s%s' % ('magnet:?xt=urn:btih:', hash)
 			name = re.findall('<h3 class="card-title">(.+?)<', result, re.DOTALL)[0].replace('Original Name: ', '')
-			name = urllib.unquote_plus(name)
+			name = unquote_plus(name)
 			name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 			if source_utils.remove_lang(name):
 				return

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/ytsws.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/ytsws.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -46,7 +49,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -62,7 +65,7 @@ class source:
 			if debrid.status() is False:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['title'].replace('&', 'and')
@@ -71,8 +74,8 @@ class source:
 			query = '%s %s' % (title, hdlr)
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
-			url = self.search_link % urllib.quote(query)
-			url = urlparse.urljoin(self.base_link, url).replace('%20', '-')
+			url = self.search_link % quote(query)
+			url = urljoin(self.base_link, url).replace('%20', '-')
 			# log_utils.log('url = %s' % url, log_utils.LOGDEBUG)
 
 			html = client.request(url)
@@ -97,7 +100,7 @@ class source:
 					hash = re.compile('btih:(.*?)&').findall(url)[0]
 
 					name = url.split('&dn=')[1]
-					name = urllib.unquote_plus(name)
+					name = unquote_plus(name)
 					name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 					if source_utils.remove_lang(name):
 						continue

--- a/lib/openscrapers/sources_openscrapers/en_Torrent/zoogle.py
+++ b/lib/openscrapers/sources_openscrapers/en_Torrent/zoogle.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus, unquote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus, unquote_plus
 
 from openscrapers.modules import client
 from openscrapers.modules import debrid
@@ -48,7 +51,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -67,10 +70,10 @@ class source:
 		try:
 			if url is None:
 				return
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -85,7 +88,7 @@ class source:
 			if debrid.status() is False:
 				return self.sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			self.title = data['tvshowtitle'] if 'tvshowtitle' in data else data['title']
@@ -100,8 +103,8 @@ class source:
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', '', query)
 
 			urls = []
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url) + str(category) + '&v=t&s=sz&sd=d'
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url) + str(category) + '&v=t&s=sz&sd=d'
 			urls.append(url)
 			urls.append(url.replace('pg=1', 'pg=2'))
 			# log_utils.log('urls = %s' % urls, log_utils.LOGDEBUG)
@@ -143,8 +146,11 @@ class source:
 						if 'magnet:' not in entry:
 							continue
 						url = 'magnet:%s' % (re.findall('href="magnet:(.+?)"', entry, re.DOTALL)[0])
-						url = urllib.unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
-						url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+						url = unquote_plus(url).replace('&amp;', '&').replace(' ', '.')
+						try:
+							url = url.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+						except:
+							pass
 						url = url.split('&tr')[0]
 						if url in str(self.sources):
 							continue
@@ -156,8 +162,11 @@ class source:
 					try:
 						name = re.findall('<a class=".+?>(.+?)</a>', entry, re.DOTALL)[0]
 						name = client.replaceHTMLCodes(name).replace('<hl>', '').replace('</hl>', '')
-						name = urllib.unquote_plus(name)
-						name = name.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+						name = unquote_plus(name)
+						try:
+							name = name.encode('ascii', errors='ignore').decode('ascii', errors='ignore')
+						except:
+							pass
 						name = re.sub('[^A-Za-z0-9]+', '.', name).lstrip('.')
 						# name = url.split('&dn=')[1]
 					except:

--- a/lib/openscrapers/sources_openscrapers/es/pelisplustv.py
+++ b/lib/openscrapers/sources_openscrapers/es/pelisplustv.py
@@ -27,7 +27,9 @@
 '''
 
 import re
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -74,7 +76,7 @@ class source:
 	def __search(self, titles, year):
 		try:
 			query = self.search_link % (cleantitle.getsearch(titles[0].replace(' ', '%20')))
-			query = urlparse.urljoin(self.base_link, query)
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i][0]
 			r = client.request(query)
 			r = client.parseDOM(r, 'li', attrs={'class': 'item everyone-item over_online haveTooltip'})
@@ -97,7 +99,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			r = client.request(query)
 			q = re.findall("'(http://www.elreyxhd.+?)'", r, re.DOTALL)[0]
 			links = client.request(q)

--- a/lib/openscrapers/sources_openscrapers/es/pepecine.py
+++ b/lib/openscrapers/sources_openscrapers/es/pepecine.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -74,8 +77,8 @@ class source:
 
 	def __search(self, titles, year, content):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.getsearch(titles[0])))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.getsearch(titles[0])))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i][0]
 			r = client.request(query)
 			r = client.parseDOM(r, 'div', attrs={'class': 'tab-content clearfix'})
@@ -104,7 +107,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			r = client.request(query)
 			links = client.parseDOM(r, 'li', attrs={'id': '\d+'})
 			for i in links:

--- a/lib/openscrapers/sources_openscrapers/es/seriespapaya.py
+++ b/lib/openscrapers/sources_openscrapers/es/seriespapaya.py
@@ -27,7 +27,9 @@
 '''
 
 import re
-import urllib
+
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import client
 from openscrapers.modules import dom_parser
@@ -45,7 +47,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'tvshowtitle': tvshowtitle}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return

--- a/lib/openscrapers/sources_openscrapers/fr/cinemay.py
+++ b/lib/openscrapers/sources_openscrapers/fr/cinemay.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urlparse
+except ImportError: from urllib.parse import parse_qs, urlparse
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -45,7 +48,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'localtitle': localtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -54,7 +57,7 @@ class source:
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle,
 			       'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -64,25 +67,20 @@ class source:
 			if url is None:
 				return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
 
 	def sources(self, url, hostDict, hostprDict):
 		try:
-			print '-------------------------------    -------------------------------'
 			sources = []
 
-			print url
-
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
-
-			print data
 
 			title = data['title']
 			year = data['year'] if 'year' in data else data['year']
@@ -131,7 +129,7 @@ class source:
 				url = client.parseDOM(url, 'div', attrs={'class': 'wbox2 video dark'})
 				url = client.parseDOM(url, 'iframe', ret='src')[0]
 
-				host = re.findall('([\w]+[.][\w]+)$', urlparse.urlparse(url.strip().lower()).netloc)[0]
+				host = re.findall('([\w]+[.][\w]+)$', urlparse(url.strip().lower()).netloc)[0]
 				if not host in hostDict: continue
 				host = client.replaceHTMLCodes(host)
 				host = host.encode('utf-8')

--- a/lib/openscrapers/sources_openscrapers/fr/dpstreaming.py
+++ b/lib/openscrapers/sources_openscrapers/fr/dpstreaming.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urlparse
+except ImportError: from urllib.parse import parse_qs, urlparse
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -46,7 +49,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'localtitle': localtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -55,7 +58,7 @@ class source:
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle,
 			       'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -65,10 +68,10 @@ class source:
 			if url is None:
 				return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -77,7 +80,7 @@ class source:
 		try:
 			print '-------------------------------    -------------------------------'
 			sources = []
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			title = data['title']
 			year = data['year'] if 'year' in data else data['year']
@@ -115,7 +118,7 @@ class source:
 				r = client.parseDOM(r, 'div', attrs={'id': 'light'})
 				r = client.parseDOM(r, 'a', ret='href')
 			for url in r:
-				host = re.findall('([\w]+[.][\w]+)$', urlparse.urlparse(url.strip().lower()).netloc)[0]
+				host = re.findall('([\w]+[.][\w]+)$', urlparse(url.strip().lower()).netloc)[0]
 				if not host in hostDict: continue
 				host = client.replaceHTMLCodes(host)
 				host = host.encode('utf-8')

--- a/lib/openscrapers/sources_openscrapers/fr/dpstreaminglive.py
+++ b/lib/openscrapers/sources_openscrapers/fr/dpstreaminglive.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urlparse
+except ImportError: from urllib.parse import parse_qs, urlparse
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -47,7 +50,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -55,7 +58,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -65,10 +68,10 @@ class source:
 			if url is None:
 				return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -78,7 +81,7 @@ class source:
 			print '-------------------------------    -------------------------------'
 			sources = []
 			print url
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			season = data['season'] if 'season' in data else False
 			episode = data['episode'] if 'episode' in data else False
@@ -90,7 +93,7 @@ class source:
 			else:
 				self.search_link = 'query=%s&submit=Submit+Query'
 				aTitle = data['title']
-			post = self.search_link % (urllib.quote_plus(cleantitle.query(aTitle)))
+			post = self.search_link % (quote_plus(cleantitle.query(aTitle)))
 			url = 'https://dpstreaming.live/recherche/'
 			t = cleantitle.get(aTitle)
 			r = client.request(url, XHR=True, referer=url, post=post)
@@ -126,7 +129,7 @@ class source:
 			for unLienUrl in unLien0b:
 				if 'gf-' in unLienUrl:
 					continue
-				dataUrl = urllib.urlencode({'pid': unLienUrl[1:]})
+				dataUrl = urlencode({'pid': unLienUrl[1:]})
 				dataUrl = client.request(url0, post=dataUrl, XHR=True, referer=url0)
 				try:
 					url = client.parseDOM(dataUrl, 'iframe', ret='src')[1]
@@ -134,7 +137,7 @@ class source:
 					url = client.parseDOM(dataUrl, 'iframe', ret='src')[0]
 				if url.startswith('//'):
 					url = url.replace('//', '', 1)
-				host = re.findall('([\w]+[.][\w]+)$', urlparse.urlparse(url.strip().lower()).netloc)[0]
+				host = re.findall('([\w]+[.][\w]+)$', urlparse(url.strip().lower()).netloc)[0]
 				if not host in hostDict: continue
 				host = client.replaceHTMLCodes(host)
 				host = host.encode('utf-8')

--- a/lib/openscrapers/sources_openscrapers/fr/fullstream.py
+++ b/lib/openscrapers/sources_openscrapers/fr/fullstream.py
@@ -26,8 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -48,14 +51,14 @@ class source:
 			url = self.__search([localtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and title != localtitle: url = self.__search([title] + source_utils.aliases_to_array(aliases),
 			                                                        year)
-			if url: return urllib.urlencode({'url': url})
+			if url: return urlencode({'url': url})
 		except:
 			return
 
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle, 'aliases': aliases, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -65,7 +68,7 @@ class source:
 			if not url:
 				return
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			tvshowtitle = data['tvshowtitle']
 			localtvshowtitle = data['localtvshowtitle']
@@ -76,7 +79,7 @@ class source:
 			if not url and tvshowtitle != localtvshowtitle: url = self.__search(
 				[tvshowtitle] + source_utils.aliases_to_array(aliases), year, season)
 
-			if url: return urllib.urlencode({'url': source_utils.strip_domain(url), 'episode': episode})
+			if url: return urlencode({'url': source_utils.strip_domain(url), 'episode': episode})
 		except:
 			return
 
@@ -87,12 +90,12 @@ class source:
 			if not url:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			url = data['url']
 			episode = data.get('episode')
 
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 
 			if episode:
 				rel = dom_parser.parse_dom(r, 'a',
@@ -122,7 +125,7 @@ class source:
 
 	def __search(self, titles, year, season='0'):
 		try:
-			query = urlparse.urljoin(self.base_link, self.search_link)
+			query = urljoin(self.base_link, self.search_link)
 
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']

--- a/lib/openscrapers/sources_openscrapers/fr/mystreamay.py
+++ b/lib/openscrapers/sources_openscrapers/fr/mystreamay.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -53,7 +56,7 @@ class source:
 		try:
 			if not url:
 				return
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 			r = client.parseDOM(r, 'a', attrs={'class': 'item',
 			                                   'href': '[^\'"]*/saison-%s/episode-%s[^\'"]*' % (season, episode)},
 			                    ret='href')[0]
@@ -72,7 +75,7 @@ class source:
 			hostDict = [(i.rsplit('.', 1)[0], i) for i in hostDict]
 			hostDict.append(['okru', 'ok.ru'])
 			locDict = [i[0] for i in hostDict]
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = client.parseDOM(r, 'ul', attrs={'class': '[^\'"]*lecteurs nop[^\'"]*'})
 			r = client.parseDOM(r, 'li')
@@ -83,7 +86,7 @@ class source:
 				if host not in locDict:
 					continue
 				host = [x[1] for x in hostDict if x[0] == host][0]
-				link = urlparse.urljoin(self.base_link, '/%s/%s/%s' % (
+				link = urljoin(self.base_link, '/%s/%s/%s' % (
 				('streamerSerie' if '/series/' in url else 'streamer'), id, streamer))
 				sources.append(
 					{'source': host, 'quality': 'SD', 'url': link, 'language': 'FR', 'info': info if info else '',
@@ -107,8 +110,8 @@ class source:
 			t = cleantitle.get(title)
 			tq = cleantitle.get(localtitle)
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
-			query = urlparse.urljoin(self.base_link, self.search_link)
-			post = urllib.urlencode({'k': "%s"}) % tq
+			query = urljoin(self.base_link, self.search_link)
+			post = urlencode({'k': "%s"}) % tq
 			r = client.request(query, post=post)
 			r = json.loads(r)
 			r = [i.get('result') for i in r if i.get('type', '').encode('utf-8') == content_type]

--- a/lib/openscrapers/sources_openscrapers/fr/planetvideos.py
+++ b/lib/openscrapers/sources_openscrapers/fr/planetvideos.py
@@ -27,8 +27,11 @@
 
 import re
 import time
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -46,7 +49,7 @@ class source:
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle,
 			       'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -56,7 +59,7 @@ class source:
 			if url is None:
 				return
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			url = self.__search(data['tvshowtitle'], season)
@@ -64,9 +67,7 @@ class source:
 				data['localtvshowtitle'], season)
 			if not url: return
 
-			print urlparse.urljoin(self.base_link, url)
-
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 
 			r = client.parseDOM(r, 'div', attrs={'class': 'keremiya_part'})
 			r = re.compile('(<a.+?/a>)', re.DOTALL).findall(''.join(r))
@@ -91,9 +92,8 @@ class source:
 			hostDict = [(i.rsplit('.', 1)[0], i) for i in hostDict]
 			locDict = [i[0] for i in hostDict]
 
-			print urlparse.urljoin(self.base_link, url)
 
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 
 			r = client.parseDOM(r, 'div', attrs={'class': 'filmicerik'})
 			r = client.parseDOM(r, 'p')
@@ -122,7 +122,7 @@ class source:
 
 			time.sleep(5)
 
-			r = client.request('http://www.protect-stream.com/secur2.php', post=urllib.urlencode({'k': k}))
+			r = client.request('http://www.protect-stream.com/secur2.php', post=urlencode({'k': k}))
 			url = client.parseDOM(r, 'a', attrs={'class': 'button'}, ret='href')[0]
 			return url
 		except:
@@ -130,8 +130,8 @@ class source:
 
 	def __search(self, title, season):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.query(title)))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.query(title)))
+			query = urljoin(self.base_link, query)
 
 			t = cleantitle.get(title)
 

--- a/lib/openscrapers/sources_openscrapers/fr/streamay.py
+++ b/lib/openscrapers/sources_openscrapers/fr/streamay.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -53,7 +56,7 @@ class source:
 		try:
 			if not url:
 				return
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 			r = client.parseDOM(r, 'a', attrs={'class': 'item',
 			                                   'href': '[^\'"]*/saison-%s/episode-%s[^\'"]*' % (season, episode)},
 			                    ret='href')[0]
@@ -72,7 +75,7 @@ class source:
 			hostDict = [(i.rsplit('.', 1)[0], i) for i in hostDict]
 			hostDict.append(['okru', 'ok.ru'])
 			locDict = [i[0] for i in hostDict]
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = client.parseDOM(r, 'ul', attrs={'class': '[^\'"]*lecteurs nop[^\'"]*'})
 			r = client.parseDOM(r, 'li')
@@ -83,7 +86,7 @@ class source:
 				if host not in locDict:
 					continue
 				host = [x[1] for x in hostDict if x[0] == host][0]
-				link = urlparse.urljoin(self.base_link, '/%s/%s/%s' % (
+				link = urljoin(self.base_link, '/%s/%s/%s' % (
 				('streamerSerie' if '/series/' in url else 'streamer'), id, streamer))
 				sources.append(
 					{'source': host, 'quality': 'SD', 'url': link, 'language': 'FR', 'info': info if info else '',
@@ -107,8 +110,8 @@ class source:
 			t = cleantitle.get(title)
 			tq = cleantitle.get(localtitle)
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
-			query = urlparse.urljoin(self.base_link, self.search_link)
-			post = urllib.urlencode({'k': "%s"}) % tq
+			query = urljoin(self.base_link, self.search_link)
+			post = urlencode({'k': "%s"}) % tq
 			r = client.request(query, post=post)
 			r = json.loads(r)
 			r = [i.get('result') for i in r if i.get('type', '').encode('utf-8') == content_type]

--- a/lib/openscrapers/sources_openscrapers/fr/zonestreaming.py
+++ b/lib/openscrapers/sources_openscrapers/fr/zonestreaming.py
@@ -26,9 +26,11 @@
 '''
 
 import re
-import urllib
-import urlparse
 
+try: from urlparse import parse_qs, urlparse
+except ImportError: from urllib.parse import parse_qs, urlparse
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
 
@@ -45,7 +47,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'localtitle': localtitle, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -54,7 +56,7 @@ class source:
 		try:
 			url = {'imdb': imdb, 'tvdb': tvdb, 'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle,
 			       'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -64,25 +66,22 @@ class source:
 			if url is None:
 				return
 
-			url = urlparse.parse_qs(url)
+			url = parse_qs(url)
 			url = dict([(i, url[i][0]) if url[i] else (i, '') for i in url])
 			url['title'], url['premiered'], url['season'], url['episode'] = title, premiered, season, episode
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
 
 	def sources(self, url, hostDict, hostprDict):
 		try:
-			print '-------------------------------    -------------------------------'
 			sources = []
 
 			print url
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
-
-			print data
 
 			title = data['title']
 			year = data['year'] if 'year' in data else data['year']
@@ -140,7 +139,7 @@ class source:
 
 				url = i
 
-				host = re.findall('([\w]+[.][\w]+)$', urlparse.urlparse(url.strip().lower()).netloc)[0]
+				host = re.findall('([\w]+[.][\w]+)$', urlparse(url.strip().lower()).netloc)[0]
 				if not host in hostDict: continue
 				host = client.replaceHTMLCodes(host)
 				host = host.encode('utf-8')

--- a/lib/openscrapers/sources_openscrapers/gr/gamatotv.py
+++ b/lib/openscrapers/sources_openscrapers/gr/gamatotv.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -56,8 +59,8 @@ class source:
 
 	def __search(self, titles, year):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.getsearch(titles[0] + ' ' + year)))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.getsearch(titles[0] + ' ' + year)))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i][0]
 			r = client.request(query)
 			r = client.parseDOM(r, 'div', attrs={'class': 'bd'})
@@ -78,7 +81,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			r = client.request(query)
 			links = client.parseDOM(r, 'div', attrs={'class': 'xg_user_generated'})
 			links = dom_parser.parse_dom(links, 'a')

--- a/lib/openscrapers/sources_openscrapers/gr/liomenoi.py
+++ b/lib/openscrapers/sources_openscrapers/gr/liomenoi.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -77,8 +80,8 @@ class source:
 
 	def __search(self, titles, year):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.getsearch(titles[0] + ' ' + year)))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.getsearch(titles[0] + ' ' + year)))
+			query = urljoin(self.base_link, query)
 			t = cleantitle.get(titles[0])
 			r = client.request(query)
 			r = client.parseDOM(r, 'div', attrs={'class': 'card'})
@@ -100,7 +103,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			r = client.request(query)
 			links = client.parseDOM(r, 'tbody')
 			links = client.parseDOM(links, 'a', ret='href')

--- a/lib/openscrapers/sources_openscrapers/gr/tainiomania.py
+++ b/lib/openscrapers/sources_openscrapers/gr/tainiomania.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -57,8 +60,8 @@ class source:
 
 	def __search(self, titles, year):
 		try:
-			query = self.search_link % (urllib.quote_plus(cleantitle.getsearch(titles[0] + ' ' + year)))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % (quote_plus(cleantitle.getsearch(titles[0] + ' ' + year)))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i][0]
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'v_pict'})
@@ -80,7 +83,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			query = urlparse.urljoin(self.base_link, url)
+			query = urljoin(self.base_link, url)
 			data = client.request(query)
 			url = re.findall('file:"([^"]+)"', data, re.DOTALL)[0]
 			quality = 'SD'

--- a/lib/openscrapers/sources_openscrapers/gr/xrysoi.py
+++ b/lib/openscrapers/sources_openscrapers/gr/xrysoi.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -46,7 +49,7 @@ class source:
 	def movie(self, imdb, title, localtitle, aliases, year):
 		try:
 			url = {'imdb': imdb, 'title': title, 'aliases': aliases, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -59,7 +62,7 @@ class source:
 			if url is None:
 				return sources
 
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 
 			title = data['title']
@@ -69,8 +72,8 @@ class source:
 			query = '%s %s' % (data['title'], data['year'])
 			query = re.sub('(\\\|/| -|:|;|\*|\?|"|\'|<|>|\|)', ' ', query)
 
-			url = self.search_link % urllib.quote_plus(query)
-			url = urlparse.urljoin(self.base_link, url)
+			url = self.search_link % quote_plus(query)
+			url = urljoin(self.base_link, url)
 
 			r = client.request(url)
 			posts = client.parseDOM(r, 'item')

--- a/lib/openscrapers/sources_openscrapers/ko/drama4u.py
+++ b/lib/openscrapers/sources_openscrapers/ko/drama4u.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -70,7 +73,7 @@ class source:
 		try:
 			if not url:
 				return
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'tab-pane'})
 			r = dom_parser.parse_dom(r, 'iframe', req='src')
@@ -116,8 +119,8 @@ class source:
 
 	def __search(self, titles):
 		try:
-			query = self.search_link % urllib.quote_plus(cleantitle.query(titles[0]))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % quote_plus(cleantitle.query(titles[0]))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'container-search'})
@@ -134,7 +137,7 @@ class source:
 		try:
 			if not url:
 				return
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'list-espisode'})
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'movie-item-espisode'})

--- a/lib/openscrapers/sources_openscrapers/ko/dramacool.py
+++ b/lib/openscrapers/sources_openscrapers/ko/dramacool.py
@@ -28,8 +28,11 @@
 
 import json
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -71,7 +74,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'watch_video'})
 			r = [i.attrs['data-src'] for i in dom_parser.parse_dom(r, 'iframe', req='data-src')]
@@ -112,8 +115,8 @@ class source:
 
 	def __search(self, titles):
 		try:
-			query = self.search_link % urllib.quote_plus(cleantitle.query(titles[0]))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % quote_plus(cleantitle.query(titles[0]))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = client.request(query, XHR=True)
 			r = json.loads(r)
@@ -127,7 +130,7 @@ class source:
 		try:
 			if not url:
 				return
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = dom_parser.parse_dom(r, 'ul', attrs={'class': 'all-episode'})
 			r = dom_parser.parse_dom(r, 'li')

--- a/lib/openscrapers/sources_openscrapers/ko/dramafire.py
+++ b/lib/openscrapers/sources_openscrapers/ko/dramafire.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle, 'aliases': aliases, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -66,7 +69,7 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			tvshowtitle = data['tvshowtitle']
 			localtvshowtitle = data['localtvshowtitle']
@@ -85,7 +88,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'entries'})
 			links = re.findall('''(?:link|file)["']?\s*:\s*["'](.+?)["']''', ''.join([i.content for i in r]))
 			links += [l.attrs['src'] for i in r for l in dom_parser.parse_dom(i, 'iframe', req='src')]
@@ -114,7 +117,7 @@ class source:
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
 			r = client.request(
-				urlparse.urljoin(self.base_link, self.search_link) % urllib.quote_plus(cleantitle.query(title)))
+				urljoin(self.base_link, self.search_link) % quote_plus(cleantitle.query(title)))
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'entries'})
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'post'})
 			r = dom_parser.parse_dom(r, 'h3', attrs={'class': 'title'})

--- a/lib/openscrapers/sources_openscrapers/ko/dramafireasia.py
+++ b/lib/openscrapers/sources_openscrapers/ko/dramafireasia.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode, quote_plus
+except ImportError: from urllib.parse import urlencode, quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -57,7 +60,7 @@ class source:
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle, 'aliases': aliases, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -66,7 +69,7 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			tvshowtitle = data['tvshowtitle']
 			localtvshowtitle = data['localtvshowtitle']
@@ -85,7 +88,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'entries'})
 			links = re.findall('''(?:link|file)["']?\s*:\s*["'](.+?)["']''', ''.join([i.content for i in r]))
 			links += [l.attrs['src'] for i in r for l in dom_parser.parse_dom(i, 'iframe', req='src')]
@@ -114,7 +117,7 @@ class source:
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
 			r = client.request(
-				urlparse.urljoin(self.base_link, self.search_link) % urllib.quote_plus(cleantitle.query(title)))
+				urljoin(self.base_link, self.search_link) % quote_plus(cleantitle.query(title)))
 			r = dom_parser.parse_dom(r, 'div', attrs={'id': 'entries'})
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'post'})
 			r = dom_parser.parse_dom(r, 'h3', attrs={'class': 'title'})

--- a/lib/openscrapers/sources_openscrapers/ko/iheartdrama.py
+++ b/lib/openscrapers/sources_openscrapers/ko/iheartdrama.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -67,7 +70,7 @@ class source:
 		try:
 			if not url:
 				return
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			episode = tvmaze.tvMaze().episodeAbsoluteNumber(tvdb, int(season), int(episode))
 			r = client.request(url)
 			r = dom_parser.parse_dom(r, 'article')
@@ -85,7 +88,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			r = client.request(urlparse.urljoin(self.base_link, url))
+			r = client.request(urljoin(self.base_link, url))
 			r = dom_parser.parse_dom(r, 'article')
 			r = dom_parser.parse_dom(r, 'div', attrs={'class': 'entry-content'})
 			links = re.findall('''(?:link|file)["']?\s*:\s*["'](.+?)["']''', ''.join([i.content for i in r]))
@@ -120,8 +123,8 @@ class source:
 
 	def __search(self, titles):
 		try:
-			query = self.search_link % urllib.quote_plus(cleantitle.query(titles[0]))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % quote_plus(cleantitle.query(titles[0]))
+			query = urljoin(self.base_link, query)
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			r = client.request(query)
 			r = dom_parser.parse_dom(r, 'article')

--- a/lib/openscrapers/sources_openscrapers/pl/alltube.py
+++ b/lib/openscrapers/sources_openscrapers/pl/alltube.py
@@ -28,7 +28,9 @@
 import base64
 import json
 import re
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cache
 from openscrapers.modules import cleantitle
@@ -90,7 +92,7 @@ class source:
 			cookies = client.request(self.base_link, output='cookie')
 			cache.cache_insert('alltube_cookie', cookies)
 			for title in titles:
-				r = client.request(urlparse.urljoin(self.base_link, self.search_link),
+				r = client.request(urljoin(self.base_link, self.search_link),
 				                   post={'search': cleantitle.query(title)}, headers={'Cookie': cookies})
 				r = self.get_rows(r, search_type)
 
@@ -182,7 +184,7 @@ class source:
 			if url is None:
 				return sources
 
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			cookies = cache.cache_get('alltube_cookie')['value']
 			result = client.request(url, headers={'Cookie': cookies})
 
@@ -219,7 +221,7 @@ class source:
 			exec _myFun in vGlobals, vLocals
 			myFun1 = vLocals['abc']
 
-			data = client.request(urlparse.urljoin(self.base_link, '/jsverify.php?op=tag'), cookie=mycookie)
+			data = client.request(urljoin(self.base_link, '/jsverify.php?op=tag'), cookie=mycookie)
 			data = byteify(json.loads(data))
 			d = {}
 			for i in range(len(data['key'])):

--- a/lib/openscrapers/sources_openscrapers/pl/alltube3d.py
+++ b/lib/openscrapers/sources_openscrapers/pl/alltube3d.py
@@ -28,7 +28,9 @@
 import base64
 import json
 import re
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cache
 from openscrapers.modules import cleantitle
@@ -87,7 +89,7 @@ class source:
 			cookies = client.request(self.base_link, output='cookie')
 			cache.cache_insert('alltube_cookie', cookies)
 			for title in titles:
-				r = client.request(urlparse.urljoin(self.base_link, self.search_link),
+				r = client.request(urljoin(self.base_link, self.search_link),
 				                   post={'search': cleantitle.query(title)}, headers={'Cookie': cookies})
 				r = self.get_rows(r, search_type)
 
@@ -160,7 +162,7 @@ class source:
 			if url is None:
 				return sources
 
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			cookies = cache.cache_get('alltube_cookie')['value']
 			result = client.request(url, headers={'Cookie': cookies})
 
@@ -197,7 +199,7 @@ class source:
 			exec _myFun in vGlobals, vLocals
 			myFun1 = vLocals['abc']
 
-			data = client.request(urlparse.urljoin(self.base_link, '/jsverify.php?op=tag'), cookie=mycookie)
+			data = client.request(urljoin(self.base_link, '/jsverify.php?op=tag'), cookie=mycookie)
 			data = byteify(json.loads(data))
 			d = {}
 			for i in range(len(data['key'])):

--- a/lib/openscrapers/sources_openscrapers/pl/cdahd.py
+++ b/lib/openscrapers/sources_openscrapers/pl/cdahd.py
@@ -26,12 +26,11 @@
 '''
 
 import re
-import urllib
 
-try:
-	import urlparse
-except:
-	import urllib.parse as urlparse
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -48,8 +47,8 @@ class source:
 
 	def do_search(self, title, local_title, year, video_type):
 		try:
-			url = urlparse.urljoin(self.base_link, self.search_link)
-			url = url % urllib.quote_plus(cleantitle.query(title))
+			url = urljoin(self.base_link, self.search_link)
+			url = url % quote_plus(cleantitle.query(title))
 			result = client.request(url)
 			result = client.parseDOM(result, 'div', attrs={'class': 'item'})
 			for row in result:
@@ -64,7 +63,7 @@ class source:
 
 				if self.name_matches(names, titles, year) and (len(year_found) == 0 or year_found[0] == year):
 					url = client.parseDOM(row, 'a', ret='href')[0]
-					return urlparse.urljoin(self.base_link, url)
+					return urljoin(self.base_link, url)
 		except:
 			return
 

--- a/lib/openscrapers/sources_openscrapers/pl/cdapl.py
+++ b/lib/openscrapers/sources_openscrapers/pl/cdapl.py
@@ -25,12 +25,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import urllib
 
-try:
-	import urlparse
-except:
-	import urllib.parse as urlparse
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote
+except ImportError: from urllib.parse import quote
 
 from openscrapers.modules import source_utils
 from openscrapers.modules import cleantitle
@@ -81,8 +80,8 @@ class source:
 			titles.append(cleantitle.normalize(cleantitle.getsearch(localtitle)))
 
 			for title in titles:
-				url = urlparse.urljoin(self.base_link, self.search_link)
-				url = url % urllib.quote(str(title).replace(" ", "_"))
+				url = urljoin(self.base_link, self.search_link)
+				url = url % quote(str(title).replace(" ", "_"))
 
 				result = client.request(url)
 				result = client.parseDOM(result, 'div', attrs={'class': 'video-clip-wrapper'})
@@ -123,8 +122,8 @@ class source:
 			titles.append(cleantitle.normalize(cleantitle.getsearch(title2)))
 
 			for title in titles:
-				url = urlparse.urljoin(self.base_link, self.search_link_ep)
-				url = url % urllib.quote(str(title).replace(" ", "_"))
+				url = urljoin(self.base_link, self.search_link_ep)
+				url = url % quote(str(title).replace(" ", "_"))
 
 				result = client.request(url)
 				result = client.parseDOM(result, 'div', attrs={'class': 'video-clip-wrapper'})
@@ -156,7 +155,7 @@ class source:
 					if url is None:
 						return sources
 
-					url = urlparse.urljoin(self.base_link, url)
+					url = urljoin(self.base_link, url)
 					result = client.request(url)
 					title = client.parseDOM(result, 'span', attrs={'style': 'margin-right: 3px;'})[0]
 					lang, info = self.get_lang_by_type(title)

--- a/lib/openscrapers/sources_openscrapers/pl/cdax.py
+++ b/lib/openscrapers/sources_openscrapers/pl/cdax.py
@@ -25,12 +25,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import urllib
 
-try:
-	import urlparse
-except:
-	import urllib.parse as urlparse
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote_plus
+except ImportError: from urllib.parse import quote_plus
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -53,8 +52,8 @@ class source:
 		try:
 			simply_name = cleantitle.get(localtitle)
 
-			query = self.search_link % urllib.quote_plus(cleantitle.query(localtitle))
-			query = urlparse.urljoin(self.base_link, query)
+			query = self.search_link % quote_plus(cleantitle.query(localtitle))
+			query = urljoin(self.base_link, query)
 			result = client.request(query)
 
 			result = client.parseDOM(result, 'div', attrs={'class': 'result-item'})

--- a/lib/openscrapers/sources_openscrapers/pl/ekinotv.py
+++ b/lib/openscrapers/sources_openscrapers/pl/ekinotv.py
@@ -25,10 +25,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-try:
-	import urlparse
-except:
-	import urllib.parse as urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -99,7 +98,7 @@ class source:
 		return self.search(tvshowtitle, localtvshowtitle, year, '/serie/')
 
 	def episode(self, url, imdb, tvdb, title, premiered, season, episode):
-		url = urlparse.urljoin(self.base_link, url)
+		url = urljoin(self.base_link, url)
 		r = client.request(url)
 		r = client.parseDOM(r, 'div', attrs={'id': 'list-series'})[0]
 		p = client.parseDOM(r, 'p')
@@ -131,7 +130,7 @@ class source:
 			if url is None:
 				return sources
 
-			r = client.request(urlparse.urljoin(self.base_link, url), redirect=False)
+			r = client.request(urljoin(self.base_link, url), redirect=False)
 
 			rows = client.parseDOM(r, 'ul', attrs={'class': 'players'})[0]
 			rows = client.parseDOM(rows, 'li')
@@ -162,7 +161,7 @@ class source:
 			splitted = url.split("'")
 			host = splitted[1]
 			video_id = splitted[3]
-			transl_url = urlparse.urljoin(self.base_link, self.resolve_link) % (host, video_id)
+			transl_url = urljoin(self.base_link, self.resolve_link) % (host, video_id)
 			result = client.request(transl_url, redirect=False, cookie="prch=true")
 			scripts = client.parseDOM(result, 'script')
 			for script in scripts:

--- a/lib/openscrapers/sources_openscrapers/pl/filiser.py
+++ b/lib/openscrapers/sources_openscrapers/pl/filiser.py
@@ -33,8 +33,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import urllib
-import urlparse
+
+try: from urlparse import urljoin
+except ImportError: from urllib.parse import urljoin
+try: from urllib import quote
+except ImportError: from urllib.parse import quote
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -57,8 +60,8 @@ class source:
 
 	def do_search(self, title, localtitle, year, is_movie_search):
 		try:
-			url = urlparse.urljoin(self.base_link, self.search_link)
-			url = url % urllib.quote(title)
+			url = urljoin(self.base_link, self.search_link)
+			url = url % quote(title)
 			result = client.request(url)
 			result = result.decode('utf-8')
 
@@ -101,7 +104,7 @@ class source:
 			if url is None:
 				return
 
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 
 			result = client.request(url)
 			result = client.parseDOM(result, 'ul', attrs={'data-season-num': season})[0]
@@ -123,7 +126,7 @@ class source:
 			if url is None:
 				return sources
 
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 
 			result = client.request(url)
 			result = client.parseDOM(result, 'div', attrs={'id': 'links'})
@@ -175,7 +178,7 @@ class source:
 
 	def resolve(self, url):
 		try:
-			url_to_exec = urlparse.urljoin(self.base_link, self.url_transl) % url
+			url_to_exec = urljoin(self.base_link, self.url_transl) % url
 			result = client.request(url_to_exec)
 
 			search_string = "var url = '";

--- a/lib/openscrapers/sources_openscrapers/ru/exfs.py
+++ b/lib/openscrapers/sources_openscrapers/ru/exfs.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -50,7 +53,7 @@ class source:
 			url = self.__search([localtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and title != localtitle:
 				url = self.__search([title] + source_utils.aliases_to_array(aliases), year)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
@@ -59,7 +62,7 @@ class source:
 			url = self.__search([localtvshowtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and tvshowtitle != localtvshowtitle:
 				url = self.__search([tvshowtitle] + source_utils.aliases_to_array(aliases), year)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
@@ -67,10 +70,10 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			data.update({'season': season, 'episode': episode})
-			return urllib.urlencode(data)
+			return urlencode(data)
 		except:
 			return
 
@@ -79,12 +82,12 @@ class source:
 		try:
 			if not url:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			url = data.get('url')
 			season = data.get('season')
 			episode = data.get('episode')
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = dom_parser.parse_dom(r, 'iframe', req='src')
 			r = [i.attrs['src'] for i in r]
@@ -112,7 +115,7 @@ class source:
 		try:
 			t = [cleantitle.get(i) for i in set(titles) if i]
 			y = ['%s' % str(year), '%s' % str(int(year) + 1), '%s' % str(int(year) - 1), '0']
-			r = client.request(urlparse.urljoin(self.base_link, self.search_link), post={'query': titles[0]}, XHR=True)
+			r = client.request(urljoin(self.base_link, self.search_link), post={'query': titles[0]}, XHR=True)
 			r = dom_parser.parse_dom(r, 'a', req='href')
 			r = [(i.attrs['href'], i.content.split('<br')[0]) for i in r]
 			r = [(i[0], re.sub('<.+?>|</.+?>', '', i[1])) for i in r]

--- a/lib/openscrapers/sources_openscrapers/ru/newkino.py
+++ b/lib/openscrapers/sources_openscrapers/ru/newkino.py
@@ -27,8 +27,11 @@
 '''
 
 import re
-import urllib
-import urlparse
+
+try: from urlparse import parse_qs, urljoin
+except ImportError: from urllib.parse import parse_qs, urljoin
+try: from urllib import urlencode
+except ImportError: from urllib.parse import urlencode
 
 from openscrapers.modules import cleantitle
 from openscrapers.modules import client
@@ -50,14 +53,14 @@ class source:
 			url = self.__search([localtitle] + source_utils.aliases_to_array(aliases), year)
 			if not url and title != localtitle:
 				url = self.__search([title] + source_utils.aliases_to_array(aliases), year)
-			return urllib.urlencode({'url': url}) if url else None
+			return urlencode({'url': url}) if url else None
 		except:
 			return
 
 	def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
 		try:
 			url = {'tvshowtitle': tvshowtitle, 'localtvshowtitle': localtvshowtitle, 'aliases': aliases, 'year': year}
-			url = urllib.urlencode(url)
+			url = urlencode(url)
 			return url
 		except:
 			return
@@ -66,10 +69,10 @@ class source:
 		try:
 			if not url:
 				return
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			data.update({'season': season, 'episode': episode, 'year': re.findall('(\d{4})', premiered)[0]})
-			return urllib.urlencode(data)
+			return urlencode(data)
 		except:
 			return
 
@@ -78,7 +81,7 @@ class source:
 		try:
 			if not url:
 				return sources
-			data = urlparse.parse_qs(url)
+			data = parse_qs(url)
 			data = dict([(i, data[i][0]) if data[i] else (i, '') for i in data])
 			url = data.get('url')
 			year = data.get('year')
@@ -93,7 +96,7 @@ class source:
 					url = self.__search([tvshowtitle] + aliases, year, season)
 				if not url:
 					return sources
-			url = urlparse.urljoin(self.base_link, url)
+			url = urljoin(self.base_link, url)
 			r = client.request(url)
 			r = dom_parser.parse_dom(r, 'iframe', req='src')
 			r = [i.attrs['src'] for i in r]


### PR DESCRIPTION
I was hoping after this pull request Openscrapers would work in Python 3. Unfortunately, that is not the case yet.

All scrapers have been (hopefully) fixed to work with Py2/3, and some other changes needed in the modules has been done.

The main problem now is, I think, `client.py`, which has some old `urllib2` functions that don't seem to be working when using the new `urllib.request` for Python 3.

I'll need more time, and possibly **help from someone better than me**, to sort out these issues.

`addon.xml` updated version to 0.0.2.007
`changelog` also updated.

**I've tested this still works in Py2, so hopefully it doesn't cause any troubles. It would be nice, however, for others to test before pushing the update to the main branch.**